### PR TITLE
fix: human readable text positioning in 90 and 270 deg rotation for barcode element

### DIFF
--- a/src/drawers/renderer.rs
+++ b/src/drawers/renderer.rs
@@ -1094,9 +1094,9 @@ fn draw_barcode_interpretation_line(
                 FieldOrientation::Rotated90 => {
                     let cy = pos.y + (bw - text_width as i32) / 2;
                     if line_above {
-                        (pos.x - rotated.width() as i32 - 2, cy)
-                    } else {
                         (pos.x + bh + 2, cy)
+                    } else {
+                        (pos.x - rotated.width() as i32 - 2, cy)
                     }
                 }
                 FieldOrientation::Rotated180 => {
@@ -1110,9 +1110,9 @@ fn draw_barcode_interpretation_line(
                 FieldOrientation::Rotated270 => {
                     let cy = pos.y + (bw - text_width as i32) / 2;
                     if line_above {
-                        (pos.x + bh + 2, cy)
-                    } else {
                         (pos.x - rotated.width() as i32 - 2, cy)
+                    } else {
+                        (pos.x + bh + 2, cy)
                     }
                 }
                 _ => (0, 0),


### PR DESCRIPTION
This fixes a bug with barcode elements in 90 and 270 degree rotations in version 0.2.1, where the barcodes were rendering the human readable text at the top side of the barcode instead of the bottom.  Disclaimer, this is just an AI fix I made for myself, not something I've spent a lot of time reviewing.

Mike