### PR TITLE
fix: use bold font for scalable ZPL fonts D, P, Q, S

### DIFF
--- a/src/drawers/renderer.rs
+++ b/src/drawers/renderer.rs
@@ -641,7 +641,7 @@ impl Renderer {
 fn get_ttf_font_data(name: &str) -> &'static [u8] {
     match name {
         "0" => FONT_HELVETICA,
-        "B" => FONT_DEJAVU_BOLD,
+        "B" | "D" | "P" | "Q" | "S" => FONT_DEJAVU_BOLD,
         "GS" => FONT_GS,
         _ => FONT_DEJAVU_MONO,
     }


### PR DESCRIPTION
## Problem

Zebra's native scalable fonts D, P, Q, and S render with heavier stroke weight than the regular `DejaVuSansMono.ttf` currently used as fallback. This causes visible differences on shipping labels where these fonts are used for large routing codes (`^AQ`), addresses (`^AD`, `^AS`), and service fields (`^AP`).

**Example — Correos Express label:**
- `^AQR,130,132` for the 5-digit routing code → digits appear thin/light instead of heavy/blocky
- `^ASR,50,70` for city/route text → text too thin compared to Zebra hardware
- `^APR,57,42` for currency → glyphs appear lighter

## Solution

One-line change in `get_ttf_font_data()` (`src/drawers/renderer.rs`): map fonts D, P, Q, S to `DejaVuSansMonoBold.ttf` (already bundled, used by font B) instead of the regular variant.

```rust
// Before
"B" => FONT_DEJAVU_BOLD,

// After
"B" | "D" | "P" | "Q" | "S" => FONT_DEJAVU_BOLD,
```

## Test results

All **78 golden tests pass** without any tolerance changes needed.