### PR TITLE
fix: parse `^CF` font designator as a single character, tolerating glued height digits

### DIFF
--- a/src/parsers/zpl_parser.rs
+++ b/src/parsers/zpl_parser.rs
@@ -317,28 +317,50 @@ impl ZplParser {
 
     fn parse_change_default_font(&mut self, command: &str) {
         let parts = split_command(command, "^CF");
-        if let Some(s) = parts.first() {
-            if !s.is_empty() {
-                self.printer.default_font.name = s.to_uppercase();
+        // The font designator is a single character; real printers and Labelary tolerate height
+        // digits glued onto it (^CFB0,30 = font B, height 0, width 30) -- the same leniency
+        // parse_change_font() already applies to ^A. Taking the whole first part as the name
+        // ("B0") matches no font and silently falls back to the default TTF, shredding layouts
+        // authored for the intended font (observed on production courier labels).
+        let (extra_height, height_idx, width_idx) = match parts.first() {
+            Some(s) if !s.is_empty() => {
+                let first = s.as_bytes();
+                let name = (first[0] as char).to_uppercase().to_string();
+                let mut probe = self.printer.default_font.clone();
+                probe.name = name.clone();
+                if probe.is_standard_font() {
+                    self.printer.default_font.name = name;
+                } else if (first[0] as char).is_ascii_digit() {
+                    // Numeric font names (1-9) are user-installed fonts on Zebra printers.
+                    // Fall back to font "0" (proportional), as parse_change_font does.
+                    self.printer.default_font.name = "0".to_string();
+                }
+                if first.len() > 1 {
+                    let glued = std::str::from_utf8(&first[1..]).unwrap_or("").to_string();
+                    (Some(glued), usize::MAX, 1usize)
+                } else {
+                    (None, 1, 2)
+                }
             }
-        }
-        let has_height = parts.get(1).and_then(|s| parse_int(s)).is_some();
-        let has_width = parts.get(2).and_then(|s| parse_int(s)).is_some();
-        if let Some(s) = parts.get(1) {
-            if let Some(v) = parse_int(s) {
-                self.printer.default_font.height = v as f64;
-            }
+            _ => (None, 1, 2),
+        };
+
+        let height = match &extra_height {
+            Some(hs) => parse_int(hs),
+            None => parts.get(height_idx).and_then(|s| parse_int(s)),
+        };
+        let width = parts.get(width_idx).and_then(|s| parse_int(s));
+        if let Some(v) = height {
+            self.printer.default_font.height = v as f64;
         }
         // Per ZPL spec: "Defining only the height or width forces the magnification to be
         // proportional to the parameter defined." When only height is given (no explicit width),
         // reset width to 0 so with_adjusted_sizes() derives it proportionally from height.
-        if has_height && !has_width {
+        if height.is_some() && width.is_none() {
             self.printer.default_font.width = 0.0;
         }
-        if let Some(s) = parts.get(2) {
-            if let Some(v) = parse_int(s) {
-                self.printer.default_font.width = v as f64;
-            }
+        if let Some(v) = width {
+            self.printer.default_font.width = v as f64;
         }
     }
 

--- a/tests/unit_zpl_parser.rs
+++ b/tests/unit_zpl_parser.rs
@@ -340,3 +340,38 @@ fn fo_right_justification() {
         labelize::elements::field_alignment::FieldAlignment::Right
     );
 }
+
+// --- ^CF single-character font designator (glued height digits) ---
+
+fn first_text(labels: &[labelize::LabelInfo]) -> &labelize::elements::text_field::TextField {
+    labels[0]
+        .elements
+        .iter()
+        .find_map(|e| match e {
+            LabelElement::Text(t) => Some(t),
+            _ => None,
+        })
+        .expect("no text element")
+}
+
+#[test]
+fn cf_font_designator_is_a_single_character_with_glued_height_digits() {
+    // Real printers and Labelary parse ^CFB0,30 as font B, height 0, width 30 -- observed
+    // verbatim in courier-generated ZPL. The designator must not swallow the height digits.
+    let labels = parse("^XA^CFB0,30^FO50,50^FDHello^FS^XZ");
+    assert_eq!(first_text(&labels).font.name, "B");
+}
+
+#[test]
+fn cf_plain_single_character_font_still_parses() {
+    let labels = parse("^XA^CF0,30^FO50,50^FDHello^FS^XZ");
+    let font = &first_text(&labels).font;
+    assert_eq!(font.name, "0");
+    assert_eq!(font.height, 30.0);
+}
+
+#[test]
+fn cf_numeric_user_font_falls_back_to_scalable_font_0() {
+    let labels = parse("^XA^CF3,20^FO50,50^FDHello^FS^XZ");
+    assert_eq!(first_text(&labels).font.name, "0");
+}


### PR DESCRIPTION
Real printers and Labelary parse `^CFB0,30` as font B, height 0, width 30. labelize takes the whole first comma part as the font name (`"B0"`), which matches no font and silently falls back to DejaVu Sans Mono — shredding layouts authored for the intended font. We hit this in production: a courier's label generator emits this malformed-but-tolerated form on every label, and the recipient-name field rendered in the wrong font, overflowing its box.

The fix mirrors the tolerance `parse_change_font()` already applies to `^A` (single-character designator, remaining characters of the first part are height digits), including the numeric-user-font fallback to font 0. Well-formed input is unchanged; three new unit tests.
