### PR TITLE
fix: tolerate leading garbage in `^FO`/`^FT` coordinates

### DIFF
--- a/src/parsers/command_utils.rs
+++ b/src/parsers/command_utils.rs
@@ -58,6 +58,22 @@ pub fn to_positive_int(s: &str) -> Option<i32> {
     s.trim().parse::<f64>().ok().map(|v| v.abs().round() as i32)
 }
 
+/// Like [`to_positive_int`] but tolerates leading garbage before the number, matching
+/// printer/Labelary leniency for malformed numeric parameters (e.g. `^FOB50,660` -> x=50,
+/// observed verbatim in courier-generated ZPL). Strict parse is tried first so well-formed
+/// input is unaffected.
+pub fn to_positive_int_lenient(s: &str) -> Option<i32> {
+    let t = s.trim();
+    to_positive_int(t).or_else(|| {
+        let start = t.find(|c: char| c.is_ascii_digit())?;
+        let digits: String = t[start..]
+            .chars()
+            .take_while(|c| c.is_ascii_digit() || *c == '.')
+            .collect();
+        to_positive_int(&digits)
+    })
+}
+
 pub fn parse_int(s: &str) -> Option<i32> {
     s.trim().parse::<i32>().ok()
 }

--- a/src/parsers/zpl_parser.rs
+++ b/src/parsers/zpl_parser.rs
@@ -446,10 +446,10 @@ impl ZplParser {
             calculate_from_bottom: false,
             ..Default::default()
         };
-        if let Some(v) = parts.first().and_then(|s| to_positive_int(s)) {
+        if let Some(v) = parts.first().and_then(|s| to_positive_int_lenient(s)) {
             pos.x = v;
         }
-        if let Some(v) = parts.get(1).and_then(|s| to_positive_int(s)) {
+        if let Some(v) = parts.get(1).and_then(|s| to_positive_int_lenient(s)) {
             pos.y = v;
         }
         if let Some(s) = parts.get(2) {
@@ -467,11 +467,11 @@ impl ZplParser {
             automatic_position: true,
             ..Default::default()
         };
-        if let Some(v) = parts.first().and_then(|s| to_positive_int(s)) {
+        if let Some(v) = parts.first().and_then(|s| to_positive_int_lenient(s)) {
             pos.x = v;
             pos.automatic_position = false;
         }
-        if let Some(v) = parts.get(1).and_then(|s| to_positive_int(s)) {
+        if let Some(v) = parts.get(1).and_then(|s| to_positive_int_lenient(s)) {
             pos.y = v;
             pos.automatic_position = false;
         }

--- a/tests/unit_zpl_parser.rs
+++ b/tests/unit_zpl_parser.rs
@@ -341,6 +341,40 @@ fn fo_right_justification() {
     );
 }
 
+// --- lenient ^FO/^FT numeric parameters ---
+
+#[test]
+fn field_origin_tolerates_leading_garbage_in_coordinates() {
+    // Real printers and Labelary render ^FOB50,660 at x=50 -- observed verbatim in
+    // courier-generated ZPL. Strict parsing yielded x=0 and overprinted fields.
+    let labels = parse("^XA^FOB50,660^A0N,30,30^FDHello^FS^XZ");
+    let text = labels[0]
+        .elements
+        .iter()
+        .find_map(|e| match e {
+            LabelElement::Text(t) => Some(t),
+            _ => None,
+        })
+        .expect("no text element");
+    assert_eq!(text.position.x, 50);
+    assert_eq!(text.position.y, 660);
+}
+
+#[test]
+fn field_origin_well_formed_coordinates_are_unchanged() {
+    let labels = parse("^XA^FO40,90^A0N,30,30^FDHello^FS^XZ");
+    let text = labels[0]
+        .elements
+        .iter()
+        .find_map(|e| match e {
+            LabelElement::Text(t) => Some(t),
+            _ => None,
+        })
+        .expect("no text element");
+    assert_eq!(text.position.x, 40);
+    assert_eq!(text.position.y, 90);
+}
+
 // --- font B Zebra metrics (measured against Labelary at magnifications 1-9) ---
 
 fn text_font(labels: &[labelize::LabelInfo]) -> labelize::elements::font::FontInfo {


### PR DESCRIPTION
Real printers and Labelary render `^FOB50,660` at x=50 (again observed verbatim in production courier ZPL — the same generator as #18). labelize's strict `parse::<f64>()` fails on `"B50"` and leaves x=0, so two fields authored side by side (`^FOB50,660` / `^FOB500,660`) overprint at the left margin into an unreadable smear.

`to_positive_int_lenient` tries the strict parse first — well-formed input takes the identical path — and only then skips leading non-digits. Used only for `^FO`/`^FT` x/y. Two new unit tests.
