### PR TITLE
feat: warn when a ZPL font has no mapping instead of substituting silently

### DIFF
--- a/src/drawers/renderer.rs
+++ b/src/drawers/renderer.rs
@@ -751,7 +751,17 @@ fn get_ttf_font_data(name: &str) -> &'static [u8] {
         "0" => FONT_HELVETICA,
         "B" | "D" | "P" | "Q" | "S" => FONT_DEJAVU_BOLD,
         "GS" => FONT_GS,
-        _ => FONT_DEJAVU_MONO,
+        // Remaining Zebra-resident fonts intentionally substitute DejaVu Sans Mono.
+        "A" | "C" | "E" | "F" | "G" | "H" | "R" | "T" | "U" | "V" | "W" | "X" | "Y" | "Z" => {
+            FONT_DEJAVU_MONO
+        }
+        _ => {
+            eprintln!(
+                "labelize: no mapping for ZPL font '{}'; substituting DejaVu Sans Mono (layout may differ)",
+                name
+            );
+            FONT_DEJAVU_MONO
+        }
     }
 }
 


### PR DESCRIPTION
An unknown font name (a `^CW`-loaded letter, or garbage from malformed input) falls back to DejaVu Sans Mono with no signal, so a wrong-font layout regression is invisible until a human looks at the output — that's how the #18 bug went unnoticed. Known resident fonts (A, C, E–H, R, T–Z) keep their intentional substitution without log noise; only genuinely unmapped names warn.
