### PR TITLE
fix: match Zebra/Labelary metrics for resident font B

### DIFF
--- a/src/drawers/renderer.rs
+++ b/src/drawers/renderer.rs
@@ -209,7 +209,11 @@ impl Renderer {
         // Font B cap height measured on Labelary: ~11.5 dots per magnification for an 11-dot
         // cell (caps overshoot the nominal cell), where DejaVu Mono Bold caps land at ~0.657 of
         // the ab_glyph scale -- hence 11.5/11/0.657 = 1.59 vs the generic 7/6 font-A correction.
-        let cap_scale: f32 = if text.font.name == "B" { 1.59 } else { 7.0 / 6.0 };
+        let cap_scale: f32 = if text.font.name == "B" {
+            1.59
+        } else {
+            7.0 / 6.0
+        };
         let bitmap_y_shift: f64 = if is_bitmap {
             scale.y = font_size * cap_scale;
 
@@ -258,11 +262,25 @@ impl Renderer {
             // Normal: draw directly onto canvas (no rotation needed)
             if let Some(ref block) = text.block {
                 draw_text_block(
-                    canvas, &font, scale, scale_x, color, x as f32, y as f32, block, &drawn_text,
+                    canvas,
+                    &font,
+                    scale,
+                    scale_x,
+                    color,
+                    x as f32,
+                    y as f32,
+                    block,
+                    &drawn_text,
                 );
             } else {
                 draw_text_with_superscript(
-                    canvas, &font, scale, color, x as f32, y as f32, &drawn_text,
+                    canvas,
+                    &font,
+                    scale,
+                    color,
+                    x as f32,
+                    y as f32,
+                    &drawn_text,
                 );
             }
         } else {
@@ -289,7 +307,15 @@ impl Renderer {
 
             if let Some(ref block) = text.block {
                 draw_text_block(
-                    &mut buf, &font, scale, scale_x, color, 0.0, 0.0, block, &drawn_text,
+                    &mut buf,
+                    &font,
+                    scale,
+                    scale_x,
+                    color,
+                    0.0,
+                    0.0,
+                    block,
+                    &drawn_text,
                 );
             } else {
                 draw_text_with_superscript(&mut buf, &font, scale, color, 0.0, 0.0, &drawn_text);

--- a/src/drawers/renderer.rs
+++ b/src/drawers/renderer.rs
@@ -172,6 +172,14 @@ impl Renderer {
         text: &TextField,
         state: &mut DrawerState,
     ) -> Result<(), String> {
+        // Zebra's built-in bitmap Font B has no lowercase glyphs; the printer (and
+        // Labelary) render lowercase field data as uppercase. Match that here so the TTF
+        // substitute doesn't silently produce mixed-case output real hardware can't.
+        let drawn_text: String = if text.font.name == "B" {
+            text.text.to_uppercase()
+        } else {
+            text.text.clone()
+        };
         let font_data = get_ttf_font_data(&text.font.name);
         let font = FontRef::try_from_slice(font_data)
             .map_err(|e| format!("failed to load font: {}", e))?;
@@ -198,8 +206,12 @@ impl Renderer {
         // The shift is computed from the actual 'H' glyph bounds at the ORIGINAL scale so that
         // it remains correct for any font size or magnification.
         let is_bitmap = text.font.is_bitmap_font();
+        // Font B cap height measured on Labelary: ~11.5 dots per magnification for an 11-dot
+        // cell (caps overshoot the nominal cell), where DejaVu Mono Bold caps land at ~0.657 of
+        // the ab_glyph scale -- hence 11.5/11/0.657 = 1.59 vs the generic 7/6 font-A correction.
+        let cap_scale: f32 = if text.font.name == "B" { 1.59 } else { 7.0 / 6.0 };
         let bitmap_y_shift: f64 = if is_bitmap {
-            scale.y = font_size * 7.0 / 6.0;
+            scale.y = font_size * cap_scale;
 
             let orig_scale = PxScale {
                 x: scale.x,
@@ -214,16 +226,16 @@ impl Renderer {
                 .map(|g| g.px_bounds().min.y as f64)
                 .unwrap_or(font_size as f64 * 0.148);
 
-            // With the 7/6-scaled em, the ascender gap also scales by 7/6.
+            // With the cap-scaled em, the ascender gap also scales by the same factor.
             // Shift the draw origin UP by that new gap so cap_top = field y.
-            -(orig_gap * 7.0 / 6.0)
+            -(orig_gap * cap_scale as f64)
         } else {
             0.0
         };
 
         // Measure text width approximately (scale already includes scale_x).
         // Use superscript-aware measurement so that ® is counted at its rendered size.
-        let text_width = measure_text_width_with_superscript(&text.text, &font, scale) as f64;
+        let text_width = measure_text_width_with_superscript(&drawn_text, &font, scale) as f64;
 
         // For field blocks, use block width for positioning instead of measured text width
         let pos_width = if let Some(ref block) = text.block {
@@ -246,17 +258,17 @@ impl Renderer {
             // Normal: draw directly onto canvas (no rotation needed)
             if let Some(ref block) = text.block {
                 draw_text_block(
-                    canvas, &font, scale, scale_x, color, x as f32, y as f32, block, &text.text,
+                    canvas, &font, scale, scale_x, color, x as f32, y as f32, block, &drawn_text,
                 );
             } else {
                 draw_text_with_superscript(
-                    canvas, &font, scale, color, x as f32, y as f32, &text.text,
+                    canvas, &font, scale, color, x as f32, y as f32, &drawn_text,
                 );
             }
         } else {
             // Non-normal: render to transparent buffer, rotate, then overlay
             let (buf_w, buf_h) = if let Some(ref block) = text.block {
-                let lines = word_wrap(&text.text, &font, scale, block.max_width as f32);
+                let lines = word_wrap(&drawn_text, &font, scale, block.max_width as f32);
                 let line_height = font_size * (1.0 + block.line_spacing as f32 / font_size);
                 let max_lines = block.max_lines.max(1) as usize;
                 let num_lines = lines.len().min(max_lines);
@@ -277,10 +289,10 @@ impl Renderer {
 
             if let Some(ref block) = text.block {
                 draw_text_block(
-                    &mut buf, &font, scale, scale_x, color, 0.0, 0.0, block, &text.text,
+                    &mut buf, &font, scale, scale_x, color, 0.0, 0.0, block, &drawn_text,
                 );
             } else {
-                draw_text_with_superscript(&mut buf, &font, scale, color, 0.0, 0.0, &text.text);
+                draw_text_with_superscript(&mut buf, &font, scale, color, 0.0, 0.0, &drawn_text);
             }
 
             let rotated = match orientation {

--- a/src/elements/font.rs
+++ b/src/elements/font.rs
@@ -80,7 +80,11 @@ impl FontInfo {
             // 2-dot intercharacter gap). With the generic rules a ^CFB,80 route code rendered
             // ~26% smaller than Labelary/Zebra output.
             let advance = if font.name == "B" { 9.0 } else { org_size[1] };
-            let width_mag_base = if font.name == "B" { org_size[0] } else { org_size[1] };
+            let width_mag_base = if font.name == "B" {
+                org_size[0]
+            } else {
+                org_size[1]
+            };
             if font.width == 0.0 && font.height == 0.0 {
                 font.width = advance;
                 font.height = org_size[0];

--- a/src/elements/font.rs
+++ b/src/elements/font.rs
@@ -73,21 +73,28 @@ impl FontInfo {
         let sizes = bitmap_font_sizes();
 
         if let Some(org_size) = sizes.get(font.name.as_str()) {
-            // Bitmap font
+            // Bitmap font.
+            // Font B empirics (measured against Labelary at magnifications 1-9): the width
+            // parameter selects magnification on the 11-dot cell height -- NOT the 7-dot glyph
+            // width -- and the character advance is 9 dots per magnification (7-dot glyph plus
+            // 2-dot intercharacter gap). With the generic rules a ^CFB,80 route code rendered
+            // ~26% smaller than Labelary/Zebra output.
+            let advance = if font.name == "B" { 9.0 } else { org_size[1] };
+            let width_mag_base = if font.name == "B" { org_size[0] } else { org_size[1] };
             if font.width == 0.0 && font.height == 0.0 {
-                font.width = org_size[1];
+                font.width = advance;
                 font.height = org_size[0];
                 return font;
             }
 
             if font.width == 0.0 {
-                font.width = org_size[1] * (font.height / org_size[0]).round().max(1.0);
+                font.width = advance * (font.height / org_size[0]).round().max(1.0);
             } else {
-                font.width = org_size[1] * (font.width / org_size[1]).round().max(1.0);
+                font.width = advance * (font.width / width_mag_base).round().max(1.0);
             }
 
             if font.height == 0.0 {
-                font.height = org_size[0] * (font.width / org_size[1]).round().max(1.0);
+                font.height = org_size[0] * (font.width / advance).round().max(1.0);
             } else {
                 font.height = org_size[0] * (font.height / org_size[0]).round().max(1.0);
             }

--- a/tests/unit_zpl_parser.rs
+++ b/tests/unit_zpl_parser.rs
@@ -341,6 +341,47 @@ fn fo_right_justification() {
     );
 }
 
+// --- font B Zebra metrics (measured against Labelary at magnifications 1-9) ---
+
+fn text_font(labels: &[labelize::LabelInfo]) -> labelize::elements::font::FontInfo {
+    labels[0]
+        .elements
+        .iter()
+        .find_map(|e| match e {
+            LabelElement::Text(t) => Some(t.font.clone()),
+            _ => None,
+        })
+        .expect("no text element")
+}
+
+#[test]
+fn font_b_height_driven_uses_nine_dot_advance() {
+    // ^CFB,80: magnification round(80/11)=7 -> cell 77, advance 9*7=63
+    // (7-dot glyph + 2-dot intercharacter gap; the gap was previously dropped).
+    let font = text_font(&parse("^XA^CFB,80^FO50,50^FDCJ^FS^XZ"));
+    assert_eq!(font.name, "B");
+    assert_eq!(font.height, 77.0);
+    assert_eq!(font.width, 63.0);
+}
+
+#[test]
+fn font_b_width_parameter_selects_magnification_on_the_cell_height() {
+    // ^CFB,0,30 (width only): Labelary selects magnification round(30/11)=3, not round(30/7)=4.
+    let font = text_font(&parse("^XA^CFB,0,30^FO50,50^FDCJ^FS^XZ"));
+    assert_eq!(font.name, "B");
+    assert_eq!(font.height, 33.0);
+    assert_eq!(font.width, 27.0);
+}
+
+#[test]
+fn other_bitmap_fonts_keep_their_existing_metrics() {
+    // Font A advance was verified against Labelary previously (6 dots/mag) -- unchanged.
+    let font = text_font(&parse("^XA^CFA,18^FO50,50^FDHello^FS^XZ"));
+    assert_eq!(font.name, "A");
+    assert_eq!(font.height, 18.0);
+    assert_eq!(font.width, 12.0);
+}
+
 // --- ^CF single-character font designator (glued height digits) ---
 
 fn first_text(labels: &[labelize::LabelInfo]) -> &labelize::elements::text_field::TextField {


### PR DESCRIPTION
Font B renders ~26% smaller than Zebra/Labelary output. Measured with probe labels (`^CFB,{h}^FDCO^FS` and `^CFB0,{w}` variants) against api.labelary.com at magnifications 1–9:

| `^CFB,h` | Labelary H×W (px) | labelize H×W (px) |
|---|---|---|
| 22 | 22×33 | 17×25 |
| 44 | 46×67 | 34×51 |
| 60 | 57×84 | 42×63 |
| 80 | 80×117 | 59×88 |
| 100 | 103×151 | 75×113 |

Three font-B-specific causes:

1. **Advance is 9 dots/mag, not 7** — the 7-dot glyph plus the 2-dot intercharacter gap; the gap is dropped, compressing text by 22%.
2. **The width parameter selects magnification on the 11-dot cell height** — Labelary maps `^CFB0,30` to magnification `round(30/11)=3`, not `round(30/7)=4`. (The two errors nearly cancel at w≈30, which is why width-driven usage can look correct while height-driven usage is visibly small — worth probing the whole parameter range when calibrating.)
3. **Caps render ~11.5 dots/mag** (they overshoot the nominal 11-dot cell); DejaVu Mono Bold caps land at ~0.657 of the ab_glyph scale, giving a cap correction of 1.59 vs the generic 7/6 used for font A.

Also renders font B uppercase-only, matching the hardware bitmap font (no lowercase glyphs) and Labelary. After the patch, probe parity vs Labelary is within 1px on heights and ≤5px on widths across magnifications 1–9. Other bitmap fonts keep their existing calibrations (font A's 6 dots/mag advance was verified previously per the existing code comment); the golden e2e suite passes unchanged. Three new unit tests pin the metric rules.

This follows the same empirical-calibration approach as font D's existing 2.317 advance ratio; a longer-term alternative is the bitmap-traced-font direction of #12.
