### PR TITLE
ci(docker): publish multi-arch images to Docker Hub and GHCR

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,445 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+    # Narrower than `v*` so a scratch tag never even starts a publish run.
+    # The `prepare` job still validates full semver — see below.
+    tags: ['v[0-9]*']
+  pull_request:
+    branches: [main]
+    # Only re-validate the image when something that affects it changes.
+    # Plain source changes are already covered by the CI workflow.
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'docker-compose.yaml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/docker.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: docker-${{ github.ref }}
+  # Supersede stale PR builds, but never abort a publish mid-flight: cancelling
+  # between the digest pushes and the manifest merge would leave dangling
+  # untagged digests and no manifest list.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# Least privilege by default; each job opts into exactly what it needs.
+permissions: {}
+
+jobs:
+  # ── Resolve which registries this run can publish to ─────────────────
+  # Secrets cannot be read from a job-level `if:`, so the decision is made
+  # once here and exposed as job outputs.
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      push: ${{ steps.cfg.outputs.push }}
+      stable: ${{ steps.cfg.outputs.stable }}
+      images: ${{ steps.cfg.outputs.images }}
+      image_names: ${{ steps.cfg.outputs.image_names }}
+      ghcr_image: ${{ steps.cfg.outputs.ghcr_image }}
+      dockerhub: ${{ steps.cfg.outputs.dockerhub }}
+    steps:
+      - name: Resolve registry configuration
+        id: cfg
+        env:
+          # The Docker Hub username is a repository VARIABLE, deliberately not a
+          # secret. Job outputs containing a secret value are redacted on the
+          # runner and arrive empty — and the account name is a substring of the
+          # image names below, so storing it as a secret would silently blank out
+          # `images`/`image_names`/`ghcr_image` and break both registries.
+          # Only the token is sensitive.
+          DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          # Optional override when the Docker Hub repo name differs.
+          DOCKERHUB_IMAGE: ${{ vars.DOCKERHUB_IMAGE }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          # The `v*` trigger is broader than semver, so validate the tag here.
+          # A scratch tag like `vtest` yields no version tags at all and must
+          # never be allowed to repoint `latest` at an arbitrary commit.
+          stable=false
+          publishable=true
+          if [ "$REF_TYPE" = "tag" ]; then
+            if [[ "$REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              stable=true
+            elif [[ "$REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+[-+][0-9A-Za-z.+-]+$ ]]; then
+              # Prerelease or build metadata: publish it, but never as `latest`.
+              stable=false
+            else
+              publishable=false
+              echo "::warning::Tag '$REF_NAME' is not a semver version (vX.Y.Z) — skipping publish."
+            fi
+          fi
+
+          # Pull requests (including from forks) build but never publish.
+          if [ "$EVENT_NAME" = "pull_request" ] || [ "$publishable" != "true" ]; then
+            push=false
+          else
+            push=true
+          fi
+
+          # GHCR rejects uppercase characters in image names.
+          ghcr_image="ghcr.io/${GITHUB_REPOSITORY,,}"
+          images="$ghcr_image"
+          image_names="$ghcr_image"
+
+          # Docker Hub only joins in once the username variable and the token
+          # secret both exist, so forks and pre-setup runs stay green.
+          if [ -n "${DOCKERHUB_USERNAME:-}" ] && [ -n "${DOCKERHUB_TOKEN:-}" ]; then
+            dockerhub=true
+            dockerhub_image="${DOCKERHUB_IMAGE:-${DOCKERHUB_USERNAME}/labelize}"
+            images="$images"$'\n'"$dockerhub_image"
+            image_names="$image_names,$dockerhub_image"
+          else
+            dockerhub=false
+            echo "::notice::Docker Hub not configured — set the DOCKERHUB_USERNAME repository *variable* and the DOCKERHUB_TOKEN *secret* to enable it. Publishing to GHCR only."
+          fi
+
+          {
+            echo "push=$push"
+            echo "stable=$stable"
+            echo "dockerhub=$dockerhub"
+            echo "ghcr_image=$ghcr_image"
+            echo "image_names=$image_names"
+            echo "images<<__EOF__"
+            echo "$images"
+            echo "__EOF__"
+          } >> "$GITHUB_OUTPUT"
+
+  # ── Build one image per architecture on a native runner ──────────────
+  # An arm64 Rust release build under QEMU takes the better part of an hour,
+  # so each platform gets a native runner and the per-platform results are
+  # stitched into a manifest list by the `merge` job.
+  build:
+    name: Build (${{ matrix.platform }})
+    needs: prepare
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Normalise platform name
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: echo "PLATFORM_PAIR=${PLATFORM//\//-}" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@v5
+        with:
+          # Keep the job token out of .git/config — nothing here needs it.
+          persist-credentials: false
+
+      - uses: docker/setup-buildx-action@v3
+        with:
+          # BuildKit defaults to 4 parallel build steps, which OOMs the 7 GB
+          # GitHub runner during Rust compiles (moby/buildkit#3969).
+          buildkitd-config-inline: |
+            [worker.oci]
+              max-parallelism = 2
+
+      - name: Log in to GHCR
+        if: needs.prepare.outputs.push == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        if: needs.prepare.outputs.push == 'true' && needs.prepare.outputs.dockerhub == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ needs.prepare.outputs.images }}
+          labels: |
+            org.opencontainers.image.title=Labelize
+            org.opencontainers.image.description=Fast ZPL & EPL label parser and renderer — convert label data to PNG/PDF
+            org.opencontainers.image.licenses=MIT
+
+      # Publish runs push a digest-only image per platform. PR runs load the
+      # image into the local daemon instead, so the smoke test can run it.
+      - name: Build and push by digest
+        id: build
+        if: needs.prepare.outputs.push == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # push-by-digest cannot carry attestation manifests.
+          provenance: false
+          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
+          outputs: type=image,"name=${{ needs.prepare.outputs.image_names }}",push-by-digest=true,name-canonical=true,push=true
+
+      - name: Build for validation
+        if: needs.prepare.outputs.push != 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          load: true
+          tags: labelize:ci-${{ env.PLATFORM_PAIR }}
+          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
+
+      - name: Smoke test image
+        if: needs.prepare.outputs.push != 'true'
+        run: |
+          set -euo pipefail
+          image="labelize:ci-${PLATFORM_PAIR}"
+
+          # ENTRYPOINT is `labelize`, so arguments replace the default CMD.
+          docker run --rm "$image" --version
+
+          docker run -d --name labelize-smoke -p 8080:8080 "$image"
+          trap 'docker logs labelize-smoke || true; docker rm -f labelize-smoke >/dev/null 2>&1 || true' EXIT
+
+          ready=0
+          for _ in $(seq 1 30); do
+            if curl -fsS http://localhost:8080/health >/dev/null; then
+              ready=1
+              break
+            fi
+            sleep 2
+          done
+          [ "$ready" = "1" ] || { echo "::error::/health never became ready"; exit 1; }
+
+          curl -fsS -X POST http://localhost:8080/convert \
+            -H 'Content-Type: application/zpl' \
+            -d '^XA^FO50,50^A0N,40,40^FDHello World^FS^XZ' \
+            -o label.png
+          [ -s label.png ] || { echo "::error::/convert returned an empty PNG"; exit 1; }
+          echo "Rendered $(wc -c < label.png) bytes of PNG"
+
+      - name: Export digest
+        if: needs.prepare.outputs.push == 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: needs.prepare.outputs.push == 'true'
+        uses: actions/upload-artifact@v6
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ── Combine the per-platform digests into one multi-arch manifest ────
+  merge:
+    name: Push manifest
+    needs: [prepare, build]
+    if: needs.prepare.outputs.push == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
+      id-token: write      # OIDC identity for the provenance attestation
+      attestations: write
+    outputs:
+      ghcr_ref: ${{ steps.manifest.outputs.ghcr_ref }}
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v6
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        if: needs.prepare.outputs.dockerhub == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ needs.prepare.outputs.images }}
+          # `latest` is managed explicitly below so prereleases never claim it.
+          flavor: latest=false
+          tags: |
+            type=ref,event=branch
+            type=raw,value=edge,enable={{is_default_branch}}
+            type=sha,format=long,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+            type=raw,value=latest,enable=${{ needs.prepare.outputs.stable == 'true' }}
+
+      - name: Create manifest list and push
+        id: manifest
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          IMAGES: ${{ needs.prepare.outputs.images }}
+          GHCR_IMAGE: ${{ needs.prepare.outputs.ghcr_image }}
+        run: |
+          set -euo pipefail
+
+          shopt -s nullglob
+          digests=(*)
+          shopt -u nullglob
+          if [ ${#digests[@]} -eq 0 ]; then
+            echo "::error::No per-platform digests were downloaded"
+            exit 1
+          fi
+
+          # Index-level annotations; the per-platform images already carry labels.
+          annotations=()
+          while IFS= read -r ann; do
+            [ -n "$ann" ] || continue
+            annotations+=(--annotation "index:${ann#manifest:}")
+          done <<< "${DOCKER_METADATA_OUTPUT_ANNOTATIONS:-}"
+
+          while IFS= read -r image; do
+            [ -n "$image" ] || continue
+
+            # Every digest was pushed to every registry, so each manifest is
+            # assembled from that registry's own copies — no cross-registry copy.
+            tags=()
+            while IFS= read -r tag; do
+              [ -n "$tag" ] || continue
+              tags+=(--tag "$tag")
+            done < <(jq -r --arg img "$image" \
+              '.tags[] | select(startswith($img + ":"))' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+
+            if [ ${#tags[@]} -eq 0 ]; then
+              echo "::error::No tags were generated for $image"
+              exit 1
+            fi
+
+            sources=()
+            for digest in "${digests[@]}"; do
+              sources+=("${image}@sha256:${digest}")
+            done
+
+            echo "::group::$image"
+            docker buildx imagetools create ${annotations[@]+"${annotations[@]}"} "${tags[@]}" "${sources[@]}"
+            docker buildx imagetools inspect "${tags[1]}"
+            echo "::endgroup::"
+          done <<< "$IMAGES"
+
+          # Hand a concrete pullable reference to the verify job.
+          ghcr_ref=$(jq -r --arg img "$GHCR_IMAGE" \
+            '[.tags[] | select(startswith($img + ":"))][0]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          echo "ghcr_ref=$ghcr_ref" >> "$GITHUB_OUTPUT"
+
+          # Digest of the merged manifest list, for the attestation subject.
+          merged_digest=$(docker buildx imagetools inspect "$ghcr_ref" \
+            --format '{{json .Manifest}}' | jq -r '.digest')
+          echo "digest=$merged_digest" >> "$GITHUB_OUTPUT"
+
+      # Signed, publicly verifiable record of which workflow run and which
+      # commit produced this exact digest. Attached to the GHCR manifest as an
+      # OCI referrer; Docker Hub is left out because its referrers support is
+      # less settled.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ${{ needs.prepare.outputs.ghcr_image }}
+          subject-digest: ${{ steps.manifest.outputs.digest }}
+          push-to-registry: true
+
+      - name: Publication summary
+        env:
+          META_TAGS: ${{ steps.meta.outputs.tags }}
+          GHCR_IMAGE: ${{ needs.prepare.outputs.ghcr_image }}
+          MERGED_DIGEST: ${{ steps.manifest.outputs.digest }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### Published image tags"
+            echo
+            echo '```'
+            printf '%s\n' "$META_TAGS"
+            echo '```'
+            echo
+            printf '**Digest:** `%s`\n' "$MERGED_DIGEST"
+            echo
+            echo 'Verify provenance:'
+            echo '```'
+            printf 'gh attestation verify oci://%s@%s --owner %s\n' \
+              "$GHCR_IMAGE" "$MERGED_DIGEST" "$OWNER"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ── Pull the published manifest back and prove it runs ───────────────
+  verify:
+    name: Verify published image
+    needs: [prepare, merge]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run published image
+        env:
+          IMAGE_REF: ${{ needs.merge.outputs.ghcr_ref }}
+        run: |
+          set -euo pipefail
+          echo "Verifying $IMAGE_REF"
+
+          docker run --rm "$IMAGE_REF" --version
+
+          docker run -d --name labelize-verify -p 8080:8080 "$IMAGE_REF"
+          trap 'docker logs labelize-verify || true; docker rm -f labelize-verify >/dev/null 2>&1 || true' EXIT
+
+          ready=0
+          for _ in $(seq 1 30); do
+            if curl -fsS http://localhost:8080/health >/dev/null; then
+              ready=1
+              break
+            fi
+            sleep 2
+          done
+          [ "$ready" = "1" ] || { echo "::error::/health never became ready"; exit 1; }

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,9 +64,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          # The `v*` trigger is broader than semver, so validate the tag here.
-          # A scratch tag like `vtest` yields no version tags at all and must
-          # never be allowed to repoint `latest` at an arbitrary commit.
+          # The `v[0-9]*` trigger glob keeps out `vtest`-style tags, but is still
+          # broader than semver, so validate properly here. A tag like `v1abc` or
+          # `v1.3` yields no version tags at all and must never be allowed to
+          # repoint `latest` at an arbitrary commit.
           stable=false
           publishable=true
           if [ "$REF_TYPE" = "tag" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Docker Publishing CI** — New `Docker` workflow builds `linux/amd64` and `linux/arm64` images on native runners and publishes multi-arch manifests to Docker Hub and GHCR on pushes to `main` and on `v*` tags; pull requests build and smoke-test the image without publishing
+- **Docker Publishing CI** — New `Docker` workflow builds `linux/amd64` and `linux/arm64` images on native runners and publishes multi-arch manifests to Docker Hub and GHCR on pushes to `main` and on semver `v[0-9]*` tags; pull requests build and smoke-test the image without publishing
 - **Image Build Provenance** — Published GHCR manifests carry a signed build provenance attestation, verifiable with `gh attestation verify`
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Docker Publishing CI** — New `Docker` workflow builds `linux/amd64` and `linux/arm64` images on native runners and publishes multi-arch manifests to Docker Hub and GHCR on pushes to `main` and on `v*` tags; pull requests build and smoke-test the image without publishing
+- **Image Build Provenance** — Published GHCR manifests carry a signed build provenance attestation, verifiable with `gh attestation verify`
+
 ### Fixed
 
 - **Docker Build** — Dropped the unsupported `--features` flag from `cargo chef prepare`, which caused `docker build` to fail with `error: unexpected argument '--features' found`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Docker Build** — Dropped the unsupported `--features` flag from `cargo chef prepare`, which caused `docker build` to fail with `error: unexpected argument '--features' found`
+
 ## [1.3.0] - 2026-07-20
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 FROM chef AS planner
 COPY . .
-RUN cargo chef prepare --recipe-path recipe.json --features serve
+RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/labelize)](https://crates.io/crates/labelize)
 [![License](https://img.shields.io/github/license/GOODBOY008/labelize)](LICENSE)
 [![Build](https://img.shields.io/github/actions/workflow/status/GOODBOY008/labelize/ci.yml?branch=main)](https://github.com/GOODBOY008/labelize/actions)
+[![Docker](https://img.shields.io/github/actions/workflow/status/GOODBOY008/labelize/docker.yml?branch=main&label=docker)](https://github.com/GOODBOY008/labelize/actions/workflows/docker.yml)
 
 > **Turn ZPL/EPL into pixels — label rendering, simplified.**
 
@@ -92,6 +93,23 @@ curl -X POST http://localhost:8080/convert \
   -o label.png
 ```
 ### Run as Docker web service
+
+Pre-built multi-arch images (`linux/amd64` + `linux/arm64`) are published on every
+release:
+
+```bash
+# Docker Hub
+docker run -p 8080:8080 goodboy008/labelize:latest
+
+# GitHub Container Registry
+docker run -p 8080:8080 ghcr.io/goodboy008/labelize:latest
+```
+
+Available tags: `latest` (newest stable release), `1.3.0` / `1.3` / `1` (pinned
+versions), and `edge` (current `main`).
+
+Or build and run it from source with Compose:
+
 ```bash
 docker compose up -d --build
 ```

--- a/docs/DOCKER_PUBLISHING.md
+++ b/docs/DOCKER_PUBLISHING.md
@@ -1,0 +1,115 @@
+# Docker Image Publishing
+
+The `Docker` workflow (`.github/workflows/docker.yml`) builds the container image
+and publishes multi-arch manifests to **Docker Hub** and the **GitHub Container
+Registry (GHCR)**.
+
+## Maintainer setup
+
+GHCR works out of the box — it authenticates with the built-in `GITHUB_TOKEN`.
+Docker Hub needs two settings, both under
+**Settings → Secrets and variables → Actions**:
+
+| Name | Kind | Value |
+|------|------|-------|
+| `DOCKERHUB_USERNAME` | **Variable** | Docker Hub account name |
+| `DOCKERHUB_TOKEN` | **Secret** | Docker Hub access token (Account Settings → Personal access tokens, `Read & Write` scope) |
+
+> [!IMPORTANT]
+> The username must be a repository **variable**, not a secret. GitHub redacts
+> job outputs that contain a secret value and passes them on as empty strings.
+> The account name is a substring of the image names this workflow computes
+> (`ghcr.io/goodboy008/labelize` contains `goodboy008`), so storing it as a
+> secret would silently blank out those outputs and break publishing to *both*
+> registries. Only the token is sensitive and belongs in Secrets.
+
+Until both exist the workflow still succeeds — it logs a notice and publishes to
+GHCR only. This keeps forks and pre-setup runs green instead of failing on
+missing credentials.
+
+One optional repository **variable** is also supported:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `DOCKERHUB_IMAGE` | `<DOCKERHUB_USERNAME>/labelize` | Docker Hub repository to push to, if the name differs |
+
+The first GHCR push creates a package that is **private** by default. To make it
+publicly pullable, open the package page → *Package settings* → *Change
+visibility* → *Public*.
+
+## Triggers and tags
+
+| Event | Tags produced |
+|-------|---------------|
+| Push to `main` | `main`, `edge`, `sha-<full-commit-sha>` |
+| Push of tag `vX.Y.Z` | `X.Y.Z`, `X.Y`, `X`, `latest` |
+| Push of tag `vX.Y.Z-rc.N` | `X.Y.Z-rc.N` only — prereleases never move `latest` |
+| Push of a non-semver `v*` tag | nothing — publish is skipped with a warning |
+| Pull request | none — builds and smoke-tests only, no publish |
+
+The `X` major tag is skipped for `v0.*` releases, where a major-only tag would be
+misleading.
+
+`latest` is assigned explicitly rather than via `flavor: latest=auto`, and it is
+gated on the `prepare` job having matched the tag against `^v[0-9]+\.[0-9]+\.[0-9]+$`.
+The workflow triggers on `v*`, which is broader than semver, so a scratch tag such
+as `vtest` would otherwise generate no version tags at all while still satisfying a
+naive "is a tag and has no `-` in it" check — repointing `latest` at an arbitrary
+commit. Such tags are rejected outright instead.
+
+## How the build is arranged
+
+Rust release builds under QEMU emulation are extremely slow, so each architecture
+is built on a native runner instead:
+
+```
+prepare ──┬─► build (linux/amd64  on ubuntu-latest)   ──┐
+          └─► build (linux/arm64  on ubuntu-24.04-arm) ──┴─► merge ─► verify
+```
+
+* **prepare** — resolves the target registries once. Secrets cannot be read from
+  a job-level `if:`, so the Docker Hub decision is made here and passed down as
+  job outputs.
+* **build** — builds a single platform and pushes it *by digest* (no tag). Layer
+  caching uses the GitHub Actions cache, scoped per platform. Attestations are
+  disabled because `push-by-digest` cannot carry attestation manifests.
+* **merge** — downloads the per-platform digests and assembles one manifest list
+  per registry with `docker buildx imagetools create`. Each registry's manifest
+  is built from its own copies of the digests, so no cross-registry blob copying
+  is needed.
+* **verify** — pulls the published manifest back and checks that the image runs:
+  `labelize --version` plus a live `GET /health`.
+
+BuildKit's default of 4 parallel build steps exhausts the 7 GB GitHub runner
+during Rust compiles ([moby/buildkit#3969](https://github.com/moby/buildkit/issues/3969)),
+so `max-parallelism` is pinned to 2.
+
+Publishing runs are never cancelled by `concurrency` — only pull request builds
+are superseded. Aborting between the digest pushes and the manifest merge would
+leave dangling untagged digests and no manifest list.
+
+## Build provenance
+
+The `merge` job attaches a signed [build provenance attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)
+to the published GHCR manifest — a record of which repository, commit, and
+workflow run produced that exact digest, signed via Sigstore and stored as an OCI
+referrer alongside the image.
+
+Anyone can verify an image is genuine before deploying it:
+
+```bash
+gh attestation verify oci://ghcr.io/goodboy008/labelize:latest --owner GOODBOY008
+```
+
+The exact command, with the digest filled in, is printed in each run's job
+summary. Docker Hub is deliberately left out — its OCI referrers support is less
+settled than GHCR's.
+
+On pull requests the build job loads the image locally instead of pushing, then
+smoke-tests it — `--version`, `GET /health`, and a real `POST /convert` that must
+return a non-empty PNG.
+
+PR builds are limited to changes that can actually affect the image (`Dockerfile`,
+`.dockerignore`, `docker-compose.yaml`, `Cargo.toml`, `Cargo.lock`, and the
+workflow itself). Ordinary source changes are already covered by the `CI`
+workflow, so they don't pay for a container rebuild.

--- a/docs/DOCKER_PUBLISHING.md
+++ b/docs/DOCKER_PUBLISHING.md
@@ -44,18 +44,27 @@ visibility* → *Public*.
 | Push to `main` | `main`, `edge`, `sha-<full-commit-sha>` |
 | Push of tag `vX.Y.Z` | `X.Y.Z`, `X.Y`, `X`, `latest` |
 | Push of tag `vX.Y.Z-rc.N` | `X.Y.Z-rc.N` only — prereleases never move `latest` |
-| Push of a non-semver `v*` tag | nothing — publish is skipped with a warning |
+| Push of tag matching `v[0-9]*` but not semver (`v1.3`, `v1abc`) | nothing — the run starts, then skips publishing with a warning |
+| Push of any other tag (`vtest`, `nightly`) | nothing — the workflow does not start at all |
 | Pull request | none — builds and smoke-tests only, no publish |
 
 The `X` major tag is skipped for `v0.*` releases, where a major-only tag would be
 misleading.
 
-`latest` is assigned explicitly rather than via `flavor: latest=auto`, and it is
-gated on the `prepare` job having matched the tag against `^v[0-9]+\.[0-9]+\.[0-9]+$`.
-The workflow triggers on `v*`, which is broader than semver, so a scratch tag such
-as `vtest` would otherwise generate no version tags at all while still satisfying a
-naive "is a tag and has no `-` in it" check — repointing `latest` at an arbitrary
-commit. Such tags are rejected outright instead.
+`latest` is guarded in two layers, because a tag that produces no version tags at
+all must never be able to repoint it at an arbitrary commit:
+
+1. **The trigger glob** is `tags: ['v[0-9]*']`, not `v*`. A tag that does not begin
+   with `v` followed by a digit — `vtest`, `vlatest`, `nightly` — never starts a
+   run, so it costs nothing and can affect nothing.
+2. **The `prepare` job** then matches the tag against `^v[0-9]+\.[0-9]+\.[0-9]+$`
+   for `latest`, and against the same pattern plus an optional
+   prerelease/build suffix to decide whether to publish at all. This catches the
+   shapes the glob still lets through — `v1.3`, `v1.3.0.4`, `v1abc` — which would
+   otherwise satisfy a naive "is a tag and has no `-` in it" check while
+   `metadata-action` emitted no version tags for them.
+
+`latest` is therefore assigned explicitly rather than via `flavor: latest=auto`.
 
 ## How the build is arranged
 


### PR DESCRIPTION
Follow-up to #14  @GOODBOY008  mentioned there that a CI job to build the image and push it to Docker Hub would be welcome. Decided to add GHCR along with Dockerhub as the GHCR should work without additional setup of secrets/token.

Adds a `Docker` workflow that publishes multi-arch images, and fixes a build-breaking bug in the merged Dockerfile.

## 🐛 The Dockerfile currently doesn't build

Before the CI could pass I hit this:

```
 > [planner 2/2] RUN cargo chef prepare --recipe-path recipe.json --features serve:
0.084 error: unexpected argument '--features' found
0.084 Usage: cargo chef prepare <--recipe-path <RECIPE_PATH>|--bin <BIN>>
ERROR: failed to solve: process "/bin/sh -c cargo chef prepare --recipe-path recipe.json --features serve" did not complete successfully: exit code: 2
```

`cargo chef prepare` only accepts `--recipe-path` and `--bin` — features belong on `cargo chef cook`, which line 11 already gets right. So `docker build` and `docker compose up --build` both fail on `main` today. First commit drops the flag; the image builds clean after that (verified locally on linux/arm64, 122 MB runtime image).

## 📦 What the workflow does

| Event | Result |
|-------|--------|
| Pull request | Build + smoke test only, no publish |
| Push to `main` | `main`, `edge`, `sha-<commit>` |
| Tag `vX.Y.Z` | `X.Y.Z`, `X.Y`, `X`, `latest` |
| Tag `vX.Y.Z-rc.N` | `X.Y.Z-rc.N` only — prereleases never move `latest` |
| Non-semver `v*` tag | Skipped with a warning — a scratch tag like `vtest` can't repoint `latest` |

Platforms: `linux/amd64` + `linux/arm64`.

```
prepare ──┬─► build (linux/amd64  on ubuntu-latest)    ──┐
          └─► build (linux/arm64  on ubuntu-24.04-arm) ──┴─► merge ─► verify
```

Each architecture builds on a **native runner** rather than under QEMU — an emulated arm64 Rust release build takes the better part of an hour. Each job pushes its platform image by digest, then `merge` assembles one manifest list per registry with `docker buildx imagetools create`. Layer caching is the GHA cache, scoped per platform.

**Validation is real, not just "it compiled":**
- PRs load the image locally and assert `labelize --version`, a live `GET /health`, and a `POST /convert` returning a non-empty PNG.
- After publishing, a `verify` job pulls the manifest back and re-runs `--version` + `/health` against the actual published artifact.

**Supply chain:**
- Signed [build provenance attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations) on the published GHCR manifest, so users can confirm an image really came from this repo before deploying it:
  ```bash
  gh attestation verify oci://ghcr.io/goodboy008/labelize:latest --owner GOODBOY008
  ```
- Least-privilege permissions (`permissions: {}` at workflow level, each job opting into only what it needs), and `persist-credentials: false` on checkout.
- BuildKit `max-parallelism = 2` — the default of 4 OOMs the 7 GB runner on Rust compiles ([moby/buildkit#3969](https://github.com/moby/buildkit/issues/3969)).
- Publish runs are never cancelled by `concurrency`; only PR builds are superseded. Aborting between the digest pushes and the manifest merge would leave dangling digests and no manifest list.

## 🔑 Setup needed from you

GHCR needs nothing — it uses the built-in `GITHUB_TOKEN`. Docker Hub needs two entries under **Settings → Secrets and variables → Actions**:

| Name | Kind | Value |
|------|------|-------|
| `DOCKERHUB_USERNAME` | **Variable** | Docker Hub account name |
| `DOCKERHUB_TOKEN` | **Secret** | Docker Hub access token, `Read & Write` scope |

⚠️ **The username goes in Variables, not Secrets** — this is deliberate and worth knowing about. GitHub redacts job outputs containing a secret value and delivers them as empty strings. Your account name is a substring of the image names the workflow computes (`ghcr.io/goodboy008/labelize` contains `goodboy008`), so putting it in Secrets would silently blank those outputs and break publishing to *both* registries. Only the token is sensitive.

**Until both exist the workflow still passes** — it logs a notice and publishes to GHCR only. That keeps forks and this PR green instead of failing on missing credentials, so you can merge first and add credentials whenever suits.

Optional repository variable `DOCKERHUB_IMAGE` overrides the push target (defaults to `<DOCKERHUB_USERNAME>/labelize`) if the repo name differs.

One manual step after the first GHCR push: the package is created **private** by default — package page → *Package settings* → *Change visibility* → *Public*.

## 📝 Also included

- `docs/DOCKER_PUBLISHING.md` — setup, tag conventions, and why the jobs are arranged this way
- README: pull instructions for both registries + a `docker` build badge
- CHANGELOG entries under `[Unreleased]`

## ✅ Testing

- Dockerfile builds end-to-end locally after the fix; image runs as non-root, `/health` returns `{"status":"ok"}`, `/convert` returns a valid 816×1216 PNG
- The `prepare` and `merge` shell steps were extracted from the YAML and exercised under bash 5 against a mocked `docker` — 22 cases covering: Docker Hub unconfigured / fully configured / half configured, `DOCKERHUB_IMAGE` override, mixed-case repo names (GHCR requires lowercase), every tag shape (`v1.3.0`, `v0.1.0`, `v10.20.30`, `v1.3.0-rc.1`, `v1.3.0+build.7`, `v1.3`, `v1.3.0.4`, `vtest`, `vlatest`), missing annotations, single-platform digests, and both hard-failure paths (zero tags generated, zero digests downloaded)
