### PR TITLE
Error qr code

### DIFF
--- a/src/barcodes/aztec.rs
+++ b/src/barcodes/aztec.rs
@@ -12,7 +12,7 @@ use rxing::{BarcodeFormat, EncodeHintValue, EncodeHints, Writer};
 ///   300     = Aztec Rune (not yet supported, falls back to default)
 pub fn encode(content: &str, magnification: i32, ec_symbol_size: i32) -> Result<RgbaImage, String> {
     if content.is_empty() {
-        return Ok(RgbaImage::from_pixel(1, 1, Rgba([0, 0, 0, 0])));
+        return Ok(RgbaImage::from_pixel(0, 0, Rgba([0, 0, 0, 0])));
     }
 
     let mag = magnification.max(1) as u32;

--- a/src/barcodes/aztec.rs
+++ b/src/barcodes/aztec.rs
@@ -12,7 +12,7 @@ use rxing::{BarcodeFormat, EncodeHintValue, EncodeHints, Writer};
 ///   300     = Aztec Rune (not yet supported, falls back to default)
 pub fn encode(content: &str, magnification: i32, ec_symbol_size: i32) -> Result<RgbaImage, String> {
     if content.is_empty() {
-        return Err("Aztec: empty content".to_string());
+        return Ok(RgbaImage::from_pixel(1, 1, Rgba([0, 0, 0, 0])));
     }
 
     let mag = magnification.max(1) as u32;

--- a/src/barcodes/datamatrix.rs
+++ b/src/barcodes/datamatrix.rs
@@ -13,7 +13,8 @@ pub fn encode(
     columns: i32,
 ) -> Result<RgbaImage, String> {
     if content.is_empty() {
-        return Err("DataMatrix: empty content".to_string());
+        // Return an empty transparent image instead of an error
+        return Ok(RgbaImage::from_pixel(0, 0, Rgba([0, 0, 0, 0])));
     }
 
     let mag = magnification.max(1) as u32;

--- a/src/barcodes/qrcode.rs
+++ b/src/barcodes/qrcode.rs
@@ -11,7 +11,8 @@ pub fn encode(
     ec_level: QrErrorCorrectionLevel,
 ) -> Result<RgbaImage, String> {
     if content.is_empty() {
-        return Err("QR code: empty content".to_string());
+        // Return an empty transparent image instead of an error
+        return Ok(RgbaImage::from_pixel(0, 0, Rgba([0, 0, 0, 0])));
     }
 
     let mag = magnification.max(1) as u32;

--- a/tests/unit_barcodes.rs
+++ b/tests/unit_barcodes.rs
@@ -265,7 +265,11 @@ fn datamatrix_empty_input_returns_error() {
     match result {
         Ok(img) => {
             assert_eq!(img.width(), 0, "empty DataMatrix code should have width 0");
-            assert_eq!(img.height(), 0, "empty DataMatrix code should have height 0");
+            assert_eq!(
+                img.height(),
+                0,
+                "empty DataMatrix code should have height 0"
+            );
         }
         Err(_) => {
             panic!("empty DataMatrix input should not return an error");

--- a/tests/unit_barcodes.rs
+++ b/tests/unit_barcodes.rs
@@ -1,8 +1,8 @@
+use image::{Rgba, RgbaImage};
 use labelize::barcodes::{
     aztec, code128, code39, datamatrix, ean13, maxicode, pdf417, qrcode, twooffive,
 };
 use labelize::elements::barcode_qr::QrErrorCorrectionLevel;
-use image::{Rgba, RgbaImage};
 
 // --- Code128 ---
 
@@ -247,7 +247,7 @@ fn aztec_empty_input_returns_empty_image() {
         Err(_) => {
             panic!("empty Aztec input should not return an error");
         }
-    }        
+    }
 }
 
 // --- DataMatrix ---
@@ -268,9 +268,9 @@ fn datamatrix_empty_input_returns_error() {
             assert_eq!(img.height(), 0, "empty DataMatrix code should have height 0");
         }
         Err(_) => {
-            panic!("empty Aztec input should not return an error");
+            panic!("empty DataMatrix input should not return an error");
         }
-    }   
+    }
 }
 
 // --- QR code ---

--- a/tests/unit_barcodes.rs
+++ b/tests/unit_barcodes.rs
@@ -238,7 +238,7 @@ fn aztec_encodes_text() {
 
 #[test]
 fn aztec_empty_input_returns_empty_image() {
-    // Empty input should return a 1×1 transparent image instead of an error
+    let result = aztec::encode("", 4, 0);
     match result {
         Ok(img) => {
             assert_eq!(img.width(), 0, "empty Aztec code should have width 0");
@@ -246,7 +246,8 @@ fn aztec_empty_input_returns_empty_image() {
         }
         Err(_) => {
             panic!("empty Aztec input should not return an error");
-      }
+        }
+    }        
 }
 
 // --- DataMatrix ---
@@ -261,7 +262,15 @@ fn datamatrix_encodes_text() {
 #[test]
 fn datamatrix_empty_input_returns_error() {
     let result = datamatrix::encode("", 4, 0, 0);
-    assert!(result.is_err(), "expected error for empty input");
+    match result {
+        Ok(img) => {
+            assert_eq!(img.width(), 0, "empty DataMatrix code should have width 0");
+            assert_eq!(img.height(), 0, "empty DataMatrix code should have height 0");
+        }
+        Err(_) => {
+            panic!("empty Aztec input should not return an error");
+        }
+    }   
 }
 
 // --- QR code ---

--- a/tests/unit_barcodes.rs
+++ b/tests/unit_barcodes.rs
@@ -237,9 +237,16 @@ fn aztec_encodes_text() {
 }
 
 #[test]
-fn aztec_empty_input_returns_error() {
-    let result = aztec::encode("", 4, 0);
-    assert!(result.is_err(), "expected error for empty input");
+fn aztec_empty_input_returns_empty_image() {
+    // Empty input should return a 1×1 transparent image instead of an error
+    match result {
+        Ok(img) => {
+            assert_eq!(img.width(), 0, "empty Aztec code should have width 0");
+            assert_eq!(img.height(), 0, "empty Aztec code should have height 0");
+        }
+        Err(_) => {
+            panic!("empty Aztec input should not return an error");
+      }
 }
 
 // --- DataMatrix ---
@@ -274,21 +281,11 @@ fn qrcode_empty_input_returns_error() {
     // Empty input should either return an error or an empty image
     match result {
         Ok(img) => {
-            // Empty image is acceptable
-            let expected_empty = RgbaImage::from_pixel(0, 0, Rgba([0, 0, 0, 0]));
-            assert_eq!(
-                img.width(),
-                expected_empty.width(),
-                "empty QR code should have width 0"
-            );
-            assert_eq!(
-                img.height(),
-                expected_empty.height(),
-                "empty QR code should have height 0"
-            );
+            assert_eq!(img.width(), 0, "empty QR code should have width 0");
+            assert_eq!(img.height(), 0, "empty QR code should have height 0");
         }
         Err(_) => {
-            // Error is also acceptable
+            panic!("empty QR input should not return an error");
         }
     }
 }

--- a/tests/unit_barcodes.rs
+++ b/tests/unit_barcodes.rs
@@ -2,6 +2,7 @@ use labelize::barcodes::{
     aztec, code128, code39, datamatrix, ean13, maxicode, pdf417, qrcode, twooffive,
 };
 use labelize::elements::barcode_qr::QrErrorCorrectionLevel;
+use image::{Rgba, RgbaImage};
 
 // --- Code128 ---
 
@@ -270,7 +271,26 @@ fn qrcode_encodes_text() {
 #[test]
 fn qrcode_empty_input_returns_error() {
     let result = qrcode::encode("", 5, QrErrorCorrectionLevel::M);
-    assert!(result.is_err(), "expected error for empty input");
+    // Empty input should either return an error or an empty image
+    match result {
+        Ok(img) => {
+            // Empty image is acceptable
+            let expected_empty = RgbaImage::from_pixel(0, 0, Rgba([0, 0, 0, 0]));
+            assert_eq!(
+                img.width(),
+                expected_empty.width(),
+                "empty QR code should have width 0"
+            );
+            assert_eq!(
+                img.height(),
+                expected_empty.height(),
+                "empty QR code should have height 0"
+            );
+        }
+        Err(_) => {
+            // Error is also acceptable
+        }
+    }
 }
 
 // --- MaxiCode ---


### PR DESCRIPTION
Suppress the error for empty QR codes or Aztec codes.
This is similar to the behaviour of a Zebra printer.