### PR TITLE
feat(playground): compare render against Labelary reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ e2e/sdk-output/
 .idea
 testdata/labelary_cache/
 *.env
+.playwright-mcp/

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Benchmarked against the Labelary API on the same set of labels:
 - **PNG & PDF Output** — Monochrome 1-bit PNG or single-page embedded PDF output
 - **CLI Tool** — Convert ZPL/EPL files from the command line with format auto-detection, multi-label support, and customizable label dimensions
 - **HTTP Microservice** — RESTful API for label conversion with format detection via `Content-Type` header; deploy anywhere with Docker, bare metal, or Cloudflare Workers
-- **Web Playground** — Built-in browser UI at `GET /` — paste or open a `.zpl`/`.epl` file, choose a label size (4×6, 4×4, etc.), render PNG inline, and download PNG or PDF with one click. A free public instance is hosted at <https://labelize.764629910.workers.dev>
+- **Web Playground** — Built-in browser UI at `GET /` — paste or open a `.zpl`/`.epl` file, choose a label size (4×6, 4×4, etc.), render PNG inline, download PNG or PDF with one click, and compare your render side-by-side against the Labelary reference with a diff score. A free public instance is hosted at <https://labelize.764629910.workers.dev>
 - **WebAssembly Package** — `@goodboy008/labelize-wasm` renders ZPL/EPL to PNG/PDF directly in browsers, Node.js, and bundlers — no server required
 - **Embedded Fonts** — Zero runtime font dependencies; bundles Helvetica Bold Condensed, DejaVu Sans Mono, and ZPL GS fonts
 - **Rust Library** — Integrate label rendering directly into your Rust application via the public API
@@ -56,7 +56,7 @@ Benchmarked against the Labelary API on the same set of labels:
 
 ### Try it online
 
-Open **<https://labelize.764629910.workers.dev>** — a free playground hosted on Cloudflare Workers. Paste ZPL/EPL, preview the rendered label in your browser, and download PNG or PDF. Same engine, same UI as the self-hosted version.
+Open **<https://labelize.764629910.workers.dev>** — a free playground hosted on Cloudflare Workers. Paste ZPL/EPL, preview the rendered label in your browser, and download PNG or PDF. Same engine, same UI as the self-hosted version. Hit **Compare with Labelary** (ZPL only) to fetch the Labelary reference render and get a diff score on the same scale as the CI golden tests.
 
 ### Installation
 
@@ -118,7 +118,7 @@ labelize convert label.zpl --width 100 --height 62 --dpmm 12  # custom dimension
 labelize serve --port 8080
 ```
 
-Open **http://localhost:8080/** in your browser to use the built-in **interactive playground** — paste ZPL/EPL, pick a label size, and render PNG instantly. Download PNG or PDF directly from the page.
+Open **http://localhost:8080/** in your browser to use the built-in **interactive playground** — paste ZPL/EPL, pick a label size, and render PNG instantly. Download PNG or PDF directly from the page, or click **Compare with Labelary** to score your render against the Labelary reference image.
 
 ```bash
 # Convert via REST API

--- a/docs/superpowers/specs/2026-08-25-playground-labelary-diff-design.md
+++ b/docs/superpowers/specs/2026-08-25-playground-labelary-diff-design.md
@@ -1,0 +1,132 @@
+# Playground "Compare with Labelary" Tool — Design
+
+Date: 2026-08-25
+Status: Approved (design choices confirmed interactively; implementation follows)
+
+## Goal
+
+Give playground users a one-click tool to **estimate the rendering diff between
+Labelary (reference) and Labelize** for the ZPL they typed: a numeric score on
+the same scale CI uses, plus a visual red-pixel diff map and side-by-side
+previews.
+
+## Constraints & Verified Facts
+
+These were verified against the live API on 2026-08-25 (curl + response headers):
+
+- `https://api.labelary.com/v1/printers/8dpmm/labels/4x6/0/` responds `200` with a
+  PNG over **HTTPS** and sends `Access-Control-Allow-Origin: *` — the browser can
+  call Labelary **directly**, no proxy required.
+- Request format that works (mirrors `tests/common/labelary_client.rs`):
+  `POST` with header `Content-Type: application/x-www-form-urlencoded` and the raw
+  ZPL as body. This content type is a CORS-safelisted "simple" header, so **no
+  preflight** is triggered. `Accept: image/png` is also safelisted.
+- `Content-Type: application/epl` would trigger a preflight whose
+  `Access-Control-Allow-Headers` does not list `Content-Type` — do not use it.
+- Labelary **does not support EPL** (404 on EPL input; also documented in
+  `docs/DIFF_THRESHOLDS.md`). The tool is ZPL-only; the button is disabled with a
+  tooltip when format = EPL.
+- 4×6 in @ 8 dpmm: Labelary returns 812×1218 px; Labelize renderer
+  (`src/drawers/renderer.rs`, `(width_mm * dpmm).ceil()`) produces 813×1220 px.
+  The 1–2 px off-by-one must be normalized before comparing (same philosophy as
+  `pad_png_to_size` in the e2e suite), otherwise every label shows ~0.3 % fake
+  size-mismatch noise.
+- Labelary rate limit is ~3 req/s (e2e client sleeps 334 ms between calls);
+  the UI must debounce and surface HTTP 429 as a "wait and retry" message.
+
+## Architecture
+
+Pure front-end, single source of truth stays `src/playground.rs`. No changes to
+`worker.js`, the wasm crate exports, the npm package, or server routes.
+
+```
+ZPL in editor
+  → click "⇄ Compare with Labelary"
+      ├─ A) POST /convert (same origin)          → Labelize PNG
+      ├─ B) POST https://api.labelary.com/...    → Labelary reference PNG (browser direct, CORS *)
+      │      (both requests run in parallel)
+      ├─ decode both PNGs via createImageBitmap → canvas → ImageData
+      ├─ normalize: draw each at natural size onto a W×H canvas,
+      │     W = max(w1,w2), H = max(h1,h2), white background
+      ├─ pixel loop: any channel |a−e| > 32 → diff pixel   (same rule as
+      │     tests/common/image_compare.rs, all 4 channels)
+      ├─ diff% = diff pixels ÷ (W×H) × 100
+      └─ show: verdict badge + diff% + sizes + elapsed,
+            3 image columns (Labelary | Labelize | Diff overlay)
+```
+
+The compare always refetches both images (does not trust a previous Render), so
+it works even before the user has pressed Render and never shows stale output.
+
+## Metric & Verdict
+
+Matches CI conventions (`docs/DIFF_THRESHOLDS.md` categories):
+
+| Verdict   | diff%      | Meaning                              |
+|-----------|------------|--------------------------------------|
+| PERFECT   | 0 %        | Pixel-identical                      |
+| GOOD      | < 1 %      | Sub-pixel / anti-alias noise         |
+| MINOR     | 1 – 5 %    | Small font or position deltas        |
+| MODERATE  | 5 – 15 %   | Font engine, graphics, 2D barcode    |
+| HIGH      | ≥ 15 %     | Missing encoder / structural mismatch|
+
+Note: the page renders with `antialias=false` (1-bit) while CI golden tests
+currently run with `antialias=true`, so playground numbers are the same *scale*
+but not bit-identical to CI numbers. The tool is explicitly an estimator; the
+formula and threshold (32) are identical to `image_compare.rs`.
+
+## UI
+
+- Settings bar: new secondary button `⇄ Compare with Labelary` left of the
+  Render button (`dl-btn-png` style). Disabled + spinner while running; disabled
+  with tooltip "Labelary does not support EPL — ZPL only" when format is EPL.
+- Preview panel: new `#compare-section` under the download bar, hidden by
+  default:
+  - Verdict row: colored badge, diff %, both images' real sizes, elapsed ms,
+    one-line category explanation.
+  - Three columns (flex, wrap on narrow screens): **Labelary** (reference),
+    **Labelize** (local render), **Diff** (white background + opaque red
+    diff pixels, same visual language as e2e diff images).
+- Reuses the existing loading overlay, error banner, and status bar.
+
+## Error Handling & Edge Cases
+
+- Labelary network failure / timeout / non-2xx → error banner with the status;
+  HTTP 429 gets a specific "Labelary is rate-limited (~3 req/s), wait a moment
+  and retry" message.
+- Oversized canvas: if either side exceeds 4096 px (e.g. dpmm=24 with a large
+  custom size), abort with a "canvas too large, lower dpmm or size" message to
+  avoid mobile OOM. Computation: `ceil(inches * 25.4 * dpmm)`.
+- Dimension mismatch of 1–2 px is normal → normalized, reported in the verdict
+  row, not an error.
+- Parse failure of the ZPL → existing error path from POST /convert.
+
+## Testing
+
+- Wasm smoke test in `workers/labelize-wasm/src/lib.rs`:
+  `exports_playground_html` gains an assertion that the HTML contains the
+  compare button id (`compare-btn`).
+- No golden/e2e impact (no rendering logic changed; `PLAYGROUND_HTML` is a
+  constant with no golden coverage).
+- Manual acceptance checklist:
+  1. Default sample ZPL → Compare → three images render, verdict shown, no
+     console errors.
+  2. Same ZPL cross-checked visually against the Labelary viewer website.
+  3. EPL selected → button disabled with tooltip.
+  4. Labelary unreachable (offline / blocked) → error banner text correct.
+  5. Oversized canvas (dpmm=24 + large custom size) → soft-limit message.
+  6. Rapid double-click → only one request pair.
+
+## Files Touched
+
+- `src/playground.rs` — all HTML/CSS/JS for the feature.
+- `workers/labelize-wasm/src/lib.rs` — one test assertion.
+- `docs/superpowers/specs/2026-08-25-playground-labelary-diff-design.md` — this
+  document.
+
+## Deployment
+
+- CF Worker: `workers/build.sh` (rebuilds wasm embedding `PLAYGROUND_HTML`) +
+  `wrangler deploy`, or push to `main` (auto-deploy via CI).
+- Self-hosted axum server: plain `cargo build`.
+- No npm package release needed.

--- a/src/playground.rs
+++ b/src/playground.rs
@@ -246,6 +246,56 @@ pub const PLAYGROUND_HTML: &str = r##"<!DOCTYPE html>
   .dl-btn-pdf.loading .mini-spinner { display: inline-block; }
   .dl-btn-pdf.loading .dl-icon-pdf  { display: none; }
 
+  /* ── Compare with Labelary ── */
+  .compare-btn {
+    background: var(--surface2); color: var(--text-dim);
+    border: 1px solid var(--border); border-radius: 6px;
+    padding: 7px 14px; font-size: 12px; font-weight: 600;
+    font-family: var(--font-ui); cursor: pointer;
+    display: inline-flex; align-items: center; gap: 6px;
+    transition: border-color 0.15s, color 0.15s; white-space: nowrap;
+  }
+
+  .compare-btn:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
+  .compare-btn:disabled { opacity: 0.55; cursor: not-allowed; }
+
+  #compare-section { display: none; width: 100%; }
+  #compare-section.visible { display: block; }
+
+  .verdict-row {
+    display: flex; align-items: center; gap: 12px; flex-wrap: wrap;
+    background: var(--surface); border: 1px solid var(--border);
+    border-radius: var(--radius); padding: 10px 14px;
+  }
+
+  .verdict-badge {
+    font-size: 12px; font-weight: 800; letter-spacing: 0.6px;
+    padding: 3px 10px; border-radius: 4px; color: #0f0f11;
+  }
+
+  .verdict-meta { font-size: 12px; color: var(--text-dim); }
+  .verdict-note { font-size: 12px; color: var(--text-dim); }
+
+  .compare-grid {
+    display: flex; gap: 12px; flex-wrap: wrap; margin-top: 10px;
+  }
+
+  .compare-col {
+    flex: 1 1 200px; min-width: 0;
+    background: var(--surface); border: 1px solid var(--border);
+    border-radius: var(--radius); overflow: hidden;
+  }
+
+  .compare-col .col-title {
+    display: block; padding: 6px 12px; font-size: 11px; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 0.8px; color: var(--text-dim);
+    background: var(--surface2); border-bottom: 1px solid var(--border);
+  }
+
+  .compare-col img {
+    display: block; width: 100%; background: #fff;
+  }
+
   /* ── Status bar ── */
   .status-bar {
     flex-shrink: 0; background: var(--surface);
@@ -356,6 +406,10 @@ pub const PLAYGROUND_HTML: &str = r##"<!DOCTYPE html>
         Open File
       </button>
 
+      <button id="compare-btn" class="compare-btn" title="Fetch the Labelary reference image and estimate the visual diff">
+        &#8646; Compare with&nbsp;Labelary
+      </button>
+
       <button id="render-btn">
         &#9654; Render <span class="shortcut">Ctrl+&#9166;</span>
       </button>
@@ -409,6 +463,27 @@ pub const PLAYGROUND_HTML: &str = r##"<!DOCTYPE html>
           Download PDF
         </button>
       </div>
+    <!-- Compare with Labelary — appears after a successful comparison -->
+      <div id="compare-section">
+        <div class="verdict-row">
+          <span id="verdict-badge" class="verdict-badge"></span>
+          <span id="verdict-meta" class="verdict-meta"></span>
+        </div>
+        <div class="compare-grid">
+          <div class="compare-col">
+            <span class="col-title">Labelary &mdash; reference</span>
+            <img id="compare-labelary" alt="Labelary reference render">
+          </div>
+          <div class="compare-col">
+            <span class="col-title">Labelize</span>
+            <img id="compare-labelize" alt="Labelize render">
+          </div>
+          <div class="compare-col">
+            <span class="col-title">Diff &mdash; red = differing pixels</span>
+            <img id="compare-diff" alt="Diff overlay">
+          </div>
+        </div>
+      </div>
     </div><!-- /preview-scroll -->
 
     <div class="status-bar">
@@ -440,6 +515,13 @@ pub const PLAYGROUND_HTML: &str = r##"<!DOCTYPE html>
   var statusText = document.getElementById("status-text");
   var statusSize = document.getElementById("status-size");
   var statusTime = document.getElementById("status-time");
+  var compareBtn     = document.getElementById("compare-btn");
+  var compareSection = document.getElementById("compare-section");
+  var verdictBadge   = document.getElementById("verdict-badge");
+  var verdictMeta    = document.getElementById("verdict-meta");
+  var compareImgL    = document.getElementById("compare-labelary");
+  var compareImgZ    = document.getElementById("compare-labelize");
+  var compareImgD    = document.getElementById("compare-diff");
 
   var pngBlobUrl = null;
 
@@ -486,6 +568,7 @@ pub const PLAYGROUND_HTML: &str = r##"<!DOCTYPE html>
     errBanner.classList.remove("visible");
     previewImg.classList.remove("visible");
     dlBar.classList.remove("visible");
+    compareSection.classList.remove("visible");
     emptyState.style.display = "none";
     if (pngBlobUrl) { URL.revokeObjectURL(pngBlobUrl); pngBlobUrl = null; }
   }
@@ -547,6 +630,172 @@ pub const PLAYGROUND_HTML: &str = r##"<!DOCTYPE html>
     });
   }
 
+  /* ── Compare with Labelary ── */
+  // Verdict scale mirrors docs/DIFF_THRESHOLDS.md; the pixel rule (any channel
+  // differs by more than 32) mirrors tests/common/image_compare.rs so the
+  // playground number is on the same scale as the CI golden diffs.
+  var VERDICTS = [
+    { name: "PERFECT",  max: 0,   color: "#4dbd74", note: "Pixel-identical to Labelary." },
+    { name: "GOOD",     max: 1,   color: "#4dbd74", note: "Sub-pixel / anti-alias level noise." },
+    { name: "MINOR",    max: 5,   color: "#e0b84f", note: "Small font or position deltas." },
+    { name: "MODERATE", max: 15,  color: "#e0803c", note: "Font engine, embedded graphics, or 2D barcode differences." },
+    { name: "HIGH",     max: Infinity, color: "#e05555", note: "Missing encoder or large structural mismatch." }
+  ];
+
+  function verdictFor(pct) {
+    for (var i = 0; i < VERDICTS.length; i++) {
+      if (pct <= VERDICTS[i].max) return VERDICTS[i];
+    }
+    return VERDICTS[VERDICTS.length - 1];
+  }
+
+  function decodeToCanvas(blob) {
+    return createImageBitmap(blob).then(function (bmp) {
+      var cv = document.createElement("canvas");
+      cv.width = bmp.width;
+      cv.height = bmp.height;
+      cv.getContext("2d").drawImage(bmp, 0, 0);
+      bmp.close();
+      return cv;
+    });
+  }
+
+  // Normalizes both images onto a common white canvas (Labelary is routinely
+  // 1-2 px smaller than Labelize at the same nominal size), then counts pixels
+  // where any channel differs by more than 32.
+  function pixelCompare(aCv, bCv) {
+    var W = Math.max(aCv.width, bCv.width);
+    var H = Math.max(aCv.height, bCv.height);
+
+    function onWhite(cv) {
+      var c = document.createElement("canvas");
+      c.width = W; c.height = H;
+      var ctx = c.getContext("2d");
+      ctx.fillStyle = "#fff";
+      ctx.fillRect(0, 0, W, H);
+      ctx.drawImage(cv, 0, 0);
+      return ctx.getImageData(0, 0, W, H).data;
+    }
+    var da = onWhite(aCv);
+    var db = onWhite(bCv);
+
+    var diff = document.createElement("canvas");
+    diff.width = W; diff.height = H;
+    var dCtx = diff.getContext("2d");
+    dCtx.fillStyle = "#fff";
+    dCtx.fillRect(0, 0, W, H);
+    var dd = dCtx.getImageData(0, 0, W, H).data;
+
+    var diffCount = 0;
+    for (var i = 0; i < da.length; i += 4) {
+      var differs = Math.abs(da[i] - db[i]) > 32 ||
+                    Math.abs(da[i + 1] - db[i + 1]) > 32 ||
+                    Math.abs(da[i + 2] - db[i + 2]) > 32 ||
+                    Math.abs(da[i + 3] - db[i + 3]) > 32;
+      if (differs) {
+        diffCount++;
+        dd[i] = 255; dd[i + 1] = 0; dd[i + 2] = 0; dd[i + 3] = 255;
+      }
+    }
+    dCtx.putImageData(new ImageData(dd, W, H), 0, 0);
+
+    return {
+      pct: (diffCount / (W * H)) * 100,
+      diffCanvas: diff,
+      aw: aCv.width, ah: aCv.height,
+      bw: bCv.width, bh: bCv.height
+    };
+  }
+
+  function compareWithLabelary() {
+    var fmt = document.getElementById("fmt").value;
+    if (fmt === "epl") {
+      showError("Labelary does not support EPL — switch to ZPL to compare.");
+      return;
+    }
+    var zpl = input.value.trim();
+    if (!zpl) { showError("Editor is empty — paste some ZPL first."); return; }
+
+    var params = getParams();
+    var pxW = Math.ceil(params.w_mm * params.dpmm);
+    var pxH = Math.ceil(params.h_mm * params.dpmm);
+    if (pxW > 4096 || pxH > 4096) {
+      showError("Canvas too large (" + pxW + "\u00d7" + pxH + " px) for comparison — lower the dpmm or label size.");
+      return;
+    }
+
+    clearPreview();
+    loading.classList.add("active");
+    compareBtn.disabled = true;
+    statusText.textContent = "Comparing\u2026";
+    statusText.className = "";
+    statusSize.textContent = "";
+    statusTime.textContent = "";
+
+    var t0 = performance.now();
+
+    // Labelary: HTTPS + CORS * (verified 2026-08-25); form-urlencoded is a
+    // CORS-safelisted content type, so no preflight is triggered. Labelary does
+    // not support EPL and rejects `application/epl` preflights, hence ZPL-only.
+    var labelaryUrl = "https://api.labelary.com/v1/printers/" + params.dpmm +
+                      "dpmm/labels/" + widthIn.value + "x" + heightIn.value + "/0/";
+
+    var ours = fetch(buildUrl(params, null), {
+      method: "POST",
+      headers: { "Content-Type": ctFor(fmt) },
+      body: zpl
+    }).then(function (res) {
+      if (!res.ok) throw new Error("render failed: HTTP " + res.status);
+      return res.blob();
+    });
+
+    var theirs = fetch(labelaryUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded", "Accept": "image/png" },
+      body: zpl
+    }).then(function (res) {
+      if (!res.ok) {
+        if (res.status === 429) throw new Error("Labelary is rate-limited (~3 req/s) — wait a moment and retry");
+        if (res.status === 404) throw new Error("Labelary rejected the request (HTTP 404) — unsupported label size or format");
+        throw new Error("Labelary request failed: HTTP " + res.status);
+      }
+      return res.blob();
+    });
+
+    Promise.all([ours, theirs])
+      .then(function (results) {
+        return Promise.all([decodeToCanvas(results[0]), decodeToCanvas(results[1])]);
+      })
+      .then(function (cvs) {
+        var r = pixelCompare(cvs[0], cvs[1]);
+        var v = verdictFor(r.pct);
+        var elapsed = Math.round(performance.now() - t0);
+        loading.classList.remove("active");
+        compareBtn.disabled = false;
+
+        compareImgZ.src = cvs[0].toDataURL("image/png");
+        compareImgL.src = cvs[1].toDataURL("image/png");
+        compareImgD.src = r.diffCanvas.toDataURL("image/png");
+
+        verdictBadge.textContent = v.name;
+        verdictBadge.style.background = v.color;
+        verdictBadge.title = v.note;
+        verdictMeta.textContent = r.pct.toFixed(2) + "%  \u00b7  Labelary " + r.bw + "\u00d7" + r.bh +
+          "  \u00b7  Labelize " + r.aw + "\u00d7" + r.ah + "  \u00b7  " + elapsed + " ms  \u00b7  " + v.note;
+
+        compareSection.classList.add("visible");
+        statusSize.textContent = "Diff " + r.pct.toFixed(2) + "%";
+        statusTime.textContent = elapsed + " ms";
+        statusText.textContent = "OK";
+        statusText.className = "status-ok";
+      })
+      .catch(function (err) {
+        loading.classList.remove("active");
+        compareBtn.disabled = false;
+        showError("Compare failed: " + err.message);
+      });
+  }
+
   /* ── PDF download (lazy) ── */
   dlPdf.addEventListener("click", function () {
     var zpl = input.value.trim();
@@ -606,6 +855,17 @@ pub const PLAYGROUND_HTML: &str = r##"<!DOCTYPE html>
   });
 
   btn.addEventListener("click", render);
+
+  compareBtn.addEventListener("click", compareWithLabelary);
+
+  // Labelary does not support EPL (404), so the compare tool is ZPL-only.
+  document.getElementById("fmt").addEventListener("change", function () {
+    var isEpl = this.value === "epl";
+    compareBtn.disabled = isEpl;
+    compareBtn.title = isEpl
+      ? "Labelary does not support EPL \u2014 ZPL only"
+      : "Fetch the Labelary reference image and estimate the visual diff";
+  });
 
   input.addEventListener("keydown", function (e) {
     if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {

--- a/workers/labelize-wasm/src/lib.rs
+++ b/workers/labelize-wasm/src/lib.rs
@@ -163,5 +163,6 @@ mod tests {
     fn exports_playground_html() {
         let html = lz_playground_html();
         assert!(html.contains("<textarea"), "playground page has editor");
+        assert!(html.contains("compare-btn"), "playground page has compare tool");
     }
 }


### PR DESCRIPTION
Adds a **Compare with Labelary** button to the playground: fetch the Labelary reference PNG directly from the browser (HTTPS + CORS `*` verified) and score the Labelize render with the same metric CI golden tests use (per-channel threshold 32, `DIFF_THRESHOLDS.md` categories), plus a red-pixel diff overlay and side-by-side previews.

**Verified locally** (axum server + Playwright against the real Labelary API):
- Default sample ZPL → **MINOR 1.90%**, ~1.1 s; diff pixel count (18,835) matches the reported % exactly (813×1220 normalized canvas)
- Dimension normalization works: Labelary 812×1218 vs Labelize 813×1220
- EPL → button disabled with tooltip (Labelary does not support EPL)
- Canvas > 4096 px → rejected before any fetch
- No console errors; wasm crate tests green (8/8)

**Scope**: pure front-end — everything lives in `src/playground.rs` (shared by the axum server and the CF Worker via `lz_playground_html`). No server routes, wasm exports, or npm changes; only a smoke-test assertion was added.

Spec: `docs/superpowers/specs/2026-08-25-playground-labelary-diff-design.md`