### PR TITLE
fix: reject malformed QR data without UTF-8 panics

### DIFF
--- a/src/elements/barcode_qr.rs
+++ b/src/elements/barcode_qr.rs
@@ -41,7 +41,10 @@ impl BarcodeQrWithData {
         }
 
         let bytes = self.data.as_bytes();
-        let mut data = &self.data[3..];
+        let mut data = self
+            .data
+            .get(3..)
+            .ok_or_else(|| "invalid qr barcode data prefix".to_string())?;
         let mut mode = QrCharacterMode::Automatic;
         let level = match bytes[0] {
             b'H' => QrErrorCorrectionLevel::H,
@@ -60,7 +63,9 @@ impl BarcodeQrWithData {
                 b'K' => QrCharacterMode::Kanji,
                 _ => QrCharacterMode::Automatic,
             };
-            data = &data[1..];
+            data = data
+                .get(1..)
+                .ok_or_else(|| "invalid qr barcode character mode".to_string())?;
         }
 
         if mode != QrCharacterMode::Binary {
@@ -74,13 +79,18 @@ impl BarcodeQrWithData {
             return Err("invalid qr barcode byte mode data".to_string());
         }
 
-        let data_len: usize = data[0..4]
+        let data_len: usize = data
+            .get(..4)
+            .ok_or_else(|| "invalid qr barcode byte mode data length".to_string())?
             .parse()
             .map_err(|_| "invalid qr barcode byte mode data length".to_string())?;
 
         let data = &data[4..];
         let data_len = data_len.min(data.len());
 
-        Ok((data[..data_len].to_string(), level, mode))
+        let content = data
+            .get(..data_len)
+            .ok_or_else(|| "qr barcode byte mode length splits a UTF-8 character".to_string())?;
+        Ok((content.to_string(), level, mode))
     }
 }

--- a/tests/unit_qr_input.rs
+++ b/tests/unit_qr_input.rs
@@ -1,0 +1,69 @@
+use labelize::elements::barcode_qr::{
+    BarcodeQr, BarcodeQrWithData, QrCharacterMode, QrErrorCorrectionLevel,
+};
+use labelize::elements::label_position::LabelPosition;
+use labelize::elements::reverse_print::ReversePrint;
+use proptest::prelude::*;
+
+fn qr(data: &str) -> BarcodeQrWithData {
+    BarcodeQrWithData {
+        reverse_print: ReversePrint { value: false },
+        barcode: BarcodeQr { magnification: 1 },
+        height: 0,
+        position: LabelPosition::default(),
+        data: data.to_string(),
+    }
+}
+
+macro_rules! rejects_without_panicking {
+    ($name:ident, $data:expr) => {
+        #[test]
+        fn $name() {
+            assert!(qr($data).get_input_data().is_err());
+        }
+    };
+}
+
+rejects_without_panicking!(binary_length_splits_utf8, "QM,B0001ä");
+rejects_without_panicking!(emoji_in_prefix, "😀");
+rejects_without_panicking!(emoji_after_level, "Q😀");
+rejects_without_panicking!(multibyte_manual_indicator, "QM,äABCDE");
+rejects_without_panicking!(multibyte_binary_length, "QM,B0😀X");
+rejects_without_panicking!(multibyte_at_prefix_boundary, "00®");
+
+#[test]
+fn valid_inputs_keep_content_level_and_mode() {
+    use QrCharacterMode::*;
+    use QrErrorCorrectionLevel::*;
+    for (input, content, level, mode) in [
+        ("QA,HELLO", "HELLO", Q, Automatic),
+        ("QA,ä😀", "ä😀", Q, Automatic),
+        ("HM,N123", "123", H, Numeric),
+        ("MM,AHELLO", "HELLO", M, Alphanumeric),
+        ("LM,K漢字", "漢字", L, Kanji),
+        ("QM,B0002ä", "ä", Q, Binary),
+        ("QM,B0004😀", "😀", Q, Binary),
+        ("QM,B0003ABCDEF", "ABC", Q, Binary),
+        // Preserve the existing truncation policy for overlong lengths.
+        ("QM,B9999ä", "ä", Q, Binary),
+        ("QM,B0003A|B", "A|B", Q, Binary),
+        ("QA,A|B", "AB", Q, Automatic),
+        ("XA,HELLO", "HELLO", H, Automatic),
+        ("QM,XHELLO", "HELLO", Q, Automatic),
+    ] {
+        assert_eq!(
+            qr(input).get_input_data().unwrap(),
+            (content.to_string(), level, mode),
+            "{input:?}"
+        );
+    }
+}
+
+proptest! {
+    #[test]
+    fn arbitrary_utf8_never_panics(data in any::<String>()) {
+        let _ = qr(&data).get_input_data();
+        let _ = qr(&format!("QM,{data}")).get_input_data();
+        let _ = qr(&format!("QM,B{data}")).get_input_data();
+    }
+}


### PR DESCRIPTION
`BarcodeQrWithData::get_input_data` panics when a fixed byte offset splits a UTF-8 character. For example, `QM,B0001ä`, `😀`, `Q😀`, `QM,äABCDE`, and `QM,B0😀X` all panic on current main. Checked string slices now return descriptive errors for these inputs.

Adds six concrete malformed-input regressions, valid ASCII and multibyte controls (including `QM,B0002ä`), and a property test over arbitrary Unicode input. Valid content, correction levels, character modes, separator handling, and the existing overlong-length truncation policy are preserved. Manual QR encoding modes are outside this fix.

Validation on Windows GNU, based on `c5ae3972`:
- Reproduced all five reported panics before the fix; eight new tests pass after it.
- `cargo test --offline -j 1 --test 'unit_*' --features skill -- --test-threads=4` passed.
- `cargo test --offline -j 1 --test e2e_diff_report -- --nocapture` passed; all 124 fixtures regenerated, both reports reviewed, no changed comparison artifacts.
- `cargo test --offline -j 1 --test e2e_golden -- --test-threads=4`: 120 passed.
- `cargo fmt --all -- --check` and `cargo clippy -j 1 --all-features -- -D warnings` passed.

Reference: [Zebra ^BQ](https://docs.zebra.com/us/en/printers/software/zpl-pg/c-zpl-zpl-commands/r-zpl-bq.html). Separate from #34, which addresses empty QR/Aztec content.