### PR TITLE
fix: honor Data Matrix dimensions and aspect ratio

### DIFF
--- a/src/barcodes/datamatrix.rs
+++ b/src/barcodes/datamatrix.rs
@@ -1,36 +1,76 @@
 use datamatrix::{DataMatrix, SymbolList};
 use image::{Rgba, RgbaImage};
 
+use crate::elements::barcode_datamatrix::DatamatrixRatio;
+
 /// Generate a Data Matrix barcode image using a proper ECC 200 encoder.
 ///
-/// `rows` and `columns` from ^BX are used to select the symbol size when
-/// both are non-zero. Otherwise, the smallest square symbol that fits the
-/// data is chosen (ZPL ^BX defaults to square symbols per the Zebra spec).
+/// Non-zero `rows` and `columns` constrain the size in modules. When both
+/// are specified, they determine the shape; otherwise selection is square.
+/// Use [`encode_with_ratio`] to explicitly select square or rectangular symbols.
 pub fn encode(
     content: &str,
     magnification: i32,
     rows: i32,
     columns: i32,
 ) -> Result<RgbaImage, String> {
+    encode_with_ratio(content, magnification, rows, columns, None)
+}
+
+/// Generate an ECC 200 symbol constrained by the ^BX dimensions and aspect ratio.
+///
+/// Zero dimensions are automatic; each positive dimension is an exact constraint.
+/// An explicit ratio constrains the shape even when dimensions are supplied.
+/// With no ratio, two fixed dimensions determine the shape; otherwise the default
+/// is square. Only standard ECC 200 sizes are used (no DMRE extensions).
+/// Negative dimensions, incompatible size/shape requests, and content that does
+/// not fit return an error. No larger or differently shaped symbol is substituted.
+/// The renderer propagates these errors to its caller.
+///
+/// See the [Zebra ^BX reference](https://docs.zebra.com/us/en/printers/software/zpl-pg/c-zpl-zpl-commands/r-zpl-bx.html).
+pub fn encode_with_ratio(
+    content: &str,
+    magnification: i32,
+    rows: i32,
+    columns: i32,
+    ratio: Option<DatamatrixRatio>,
+) -> Result<RgbaImage, String> {
     if content.is_empty() {
         return Err("DataMatrix: empty content".to_string());
+    }
+    if rows < 0 || columns < 0 {
+        return Err("DataMatrix: rows and columns must be non-negative".to_string());
     }
 
     let mag = magnification.max(1) as u32;
 
-    // Build a symbol list: if rows/columns are specified, try to match
-    // a specific size. Otherwise default to square-only (ZPL standard).
-    let symbol_list = if rows > 0 && columns > 0 {
-        // Try to find a matching symbol size — fall back to square-only
-        SymbolList::default().enforce_height_in(rows as usize..=rows as usize)
-    } else {
-        SymbolList::default().enforce_square()
+    let mut symbol_list = match ratio {
+        Some(DatamatrixRatio::Square) => SymbolList::default().enforce_square(),
+        Some(DatamatrixRatio::Rectangular) => SymbolList::default().enforce_rectangular(),
+        None if rows > 0 && columns > 0 => SymbolList::default(),
+        None => SymbolList::default().enforce_square(),
     };
+    if rows > 0 {
+        symbol_list = symbol_list.enforce_height_in(rows as usize..=rows as usize);
+    }
+    if columns > 0 {
+        symbol_list = symbol_list.enforce_width_in(columns as usize..=columns as usize);
+    }
+    if symbol_list.is_empty() {
+        return Err(format!(
+            "DataMatrix: unsupported dimensions/ratio (rows={rows}, columns={columns}, ratio={ratio:?})"
+        ));
+    }
 
-    let code = DataMatrix::encode(content.as_bytes(), symbol_list)
-        .or_else(|_| {
-            // If the specific size didn't work, fall back to square-only
-            DataMatrix::encode(content.as_bytes(), SymbolList::default().enforce_square())
+    let code = DataMatrix::encode(content.as_bytes(), symbol_list.clone())
+        .or_else(|error| {
+            // The encoder's multi-size planner can reject compressible content
+            // when none of the candidates can hold its uncompressed bytes.
+            // Retry individual allowed sizes; never relax the ^BX constraints.
+            symbol_list
+                .iter()
+                .find_map(|size| DataMatrix::encode(content.as_bytes(), size).ok())
+                .ok_or(error)
         })
         .map_err(|e| format!("DataMatrix encoding failed: {:?}", e))?;
 

--- a/src/drawers/renderer.rs
+++ b/src/drawers/renderer.rs
@@ -945,8 +945,13 @@ impl Renderer {
         bc: &crate::elements::barcode_datamatrix::BarcodeDatamatrixWithData,
     ) -> Result<(), String> {
         let scale = bc.barcode.height.max(1);
-        let img_raw =
-            barcodes::datamatrix::encode(&bc.data, scale, bc.barcode.rows, bc.barcode.columns)?;
+        let img_raw = barcodes::datamatrix::encode_with_ratio(
+            &bc.data,
+            scale,
+            bc.barcode.rows,
+            bc.barcode.columns,
+            bc.barcode.ratio,
+        )?;
         let pos = adjust_image_typeset_position(&img_raw, &bc.position, bc.barcode.orientation);
         overlay_with_rotation(canvas, &img_raw, &pos, bc.barcode.orientation);
         Ok(())

--- a/tests/unit_datamatrix.rs
+++ b/tests/unit_datamatrix.rs
@@ -1,0 +1,150 @@
+use image::RgbaImage;
+use labelize::barcodes::datamatrix;
+use labelize::elements::barcode_datamatrix::DatamatrixRatio;
+use labelize::{DrawerOptions, Renderer, ZplParser};
+
+const PAYLOAD: &str = "ABCD12345678901234567890efgh";
+
+#[test]
+fn fixed_rectangle_preserves_both_dimensions() {
+    for content in ["A", PAYLOAD] {
+        let img = datamatrix::encode(content, 1, 12, 36).unwrap();
+        assert_eq!(img.dimensions(), (36, 12), "{content}");
+    }
+}
+
+#[test]
+fn fixed_size_too_small_returns_error() {
+    assert!(datamatrix::encode(PAYLOAD, 1, 10, 10).is_err());
+}
+
+#[test]
+fn partial_rectangle_accepts_content_that_fits_after_compression() {
+    let img = datamatrix::encode_with_ratio(PAYLOAD, 1, 12, 0, Some(DatamatrixRatio::Rectangular))
+        .unwrap();
+    assert_eq!(img.dimensions(), (36, 12));
+}
+
+#[test]
+fn automatic_and_partial_dimensions_respect_shape() {
+    use DatamatrixRatio::{Rectangular, Square};
+    for (rows, columns, ratio, width, height) in [
+        (0, 0, None, 10, 10),
+        (0, 0, Some(Square), 10, 10),
+        (0, 0, Some(Rectangular), 18, 8),
+        (26, 26, Some(Square), 26, 26),
+        (26, 0, Some(Square), 26, 26),
+        (0, 26, Some(Square), 26, 26),
+        (26, 0, None, 26, 26),
+        (0, 26, None, 26, 26),
+        (12, 36, Some(Rectangular), 36, 12),
+        (12, 0, Some(Rectangular), 26, 12),
+        (0, 36, Some(Rectangular), 36, 12),
+    ] {
+        let img = datamatrix::encode_with_ratio("A", 1, rows, columns, ratio).unwrap();
+        assert_eq!(
+            img.dimensions(),
+            (width, height),
+            "{rows}, {columns}, {ratio:?}"
+        );
+    }
+}
+
+#[test]
+fn invalid_or_conflicting_constraints_return_errors() {
+    use DatamatrixRatio::{Rectangular, Square};
+    for (rows, columns, ratio) in [
+        (-1, 0, None),
+        (0, -1, None),
+        (11, 11, None),
+        (12, 14, None),
+        (200, 200, None),
+        (12, 36, Some(Square)),
+        (18, 18, Some(Rectangular)),
+        (26, 0, Some(Rectangular)),
+    ] {
+        assert!(datamatrix::encode_with_ratio("A", 1, rows, columns, ratio).is_err());
+    }
+    // A rectangle-only request must not fall back to a larger square.
+    assert!(datamatrix::encode_with_ratio(&"A".repeat(200), 1, 0, 0, Some(Rectangular)).is_err());
+    // A partial fixed size must not be relaxed when the payload does not fit.
+    for (rows, columns) in [(10, 0), (0, 10)] {
+        assert!(datamatrix::encode_with_ratio(PAYLOAD, 1, rows, columns, Some(Square)).is_err());
+    }
+}
+
+#[test]
+fn magnification_scales_modules_without_changing_the_symbol() {
+    let modules = datamatrix::encode(PAYLOAD, 1, 12, 36).unwrap();
+    for mag in [2, 3, 5] {
+        let scaled = datamatrix::encode(PAYLOAD, mag, 12, 36).unwrap();
+        assert_eq!(scaled.dimensions(), (36 * mag as u32, 12 * mag as u32));
+        for (x, y, pixel) in scaled.enumerate_pixels() {
+            assert_eq!(pixel, modules.get_pixel(x / mag as u32, y / mag as u32));
+        }
+    }
+}
+
+fn render_bx(parameters: &str, content: &str) -> Result<RgbaImage, String> {
+    let zpl = format!("^XA^FO10,20^BX{parameters}^FD{content}^FS^XZ");
+    let labels = ZplParser::new().parse(zpl.as_bytes())?;
+    assert_eq!(labels.len(), 1);
+    let options = DrawerOptions {
+        label_width_mm: 60.0,
+        label_height_mm: 40.0,
+        dpmm: 8,
+        ..Default::default()
+    };
+    let mut png = Vec::new();
+    Renderer::new().draw_label_as_png(&labels[0], &mut png, options)?;
+    Ok(image::load_from_memory(&png).unwrap().to_rgba8())
+}
+
+fn ink_bounds(image: &RgbaImage) -> (u32, u32, u32, u32) {
+    let mut min_x = image.width();
+    let mut min_y = image.height();
+    let mut max_x = 0;
+    let mut max_y = 0;
+    for (x, y, pixel) in image.enumerate_pixels() {
+        if pixel[0] < 128 && pixel[3] > 0 {
+            min_x = min_x.min(x);
+            min_y = min_y.min(y);
+            max_x = max_x.max(x);
+            max_y = max_y.max(y);
+        }
+    }
+    assert!(min_x <= max_x && min_y <= max_y, "no barcode rendered");
+    (min_x, min_y, max_x - min_x + 1, max_y - min_y + 1)
+}
+
+#[test]
+fn zpl_renderer_honors_dimensions_ratio_and_magnification() {
+    for (parameters, content, width, height) in [
+        ("N,1,200,36,12,,_,2", PAYLOAD, 36, 12),
+        ("N,3,200,36,12,,_,2", PAYLOAD, 108, 36),
+        ("N,1,200,0,0,,_,2", "A", 18, 8),
+        ("N,2,200,0,0,,_,2", "A", 36, 16),
+        ("N,1,200,0,0,,_,1", "A", 10, 10),
+        ("N,1,200", "A", 10, 10),
+        ("N,1,200,36,0,,_,2", PAYLOAD, 36, 12),
+        ("N,1,200,0,12,,_,2", PAYLOAD, 36, 12),
+    ] {
+        let image = render_bx(parameters, content).unwrap_or_else(|e| panic!("{parameters}: {e}"));
+        assert_eq!(ink_bounds(&image), (10, 20, width, height), "{parameters}");
+    }
+}
+
+#[test]
+fn zpl_renderer_propagates_invalid_size_errors() {
+    for parameters in [
+        "N,1,200,10,10,,_,1",
+        "N,1,200,14,12,,_,2",
+        "N,1,200,36,12,,_,1",
+        "N,1,200,18,18,,_,2",
+    ] {
+        let error = render_bx(parameters, PAYLOAD)
+            .err()
+            .expect("invalid dimensions must fail");
+        assert!(error.contains("DataMatrix"), "{parameters}: {error}");
+    }
+}


### PR DESCRIPTION
With `ABCD12345678901234567890efgh`, requests for both 12 rows × 36 columns and an undersized 10 × 10 currently produce an 18 × 18 square. The encoder filters only height and falls back to unrestricted square symbols; the renderer also drops the parsed aspect ratio. This change renders the requested 12 × 36 symbol and returns an error for the undersized 10 × 10 request.

Each positive dimension now constrains the symbol in modules; zero leaves that dimension automatic. The renderer passes the parsed square/rectangular ratio to a new `encode_with_ratio` entry point. Negative dimensions, unsupported size combinations, conflicting shape constraints, and content that cannot fit return `Err`, propagated by the renderer. The existing four-argument `encode` API remains available: two fixed dimensions determine its shape, otherwise it defaults to square. Explicit ratio requests must agree with fixed dimensions.

The dependency's multi-size planner can reject compressible content even when an allowed size fits (12 rows, automatic columns, the payload above). On encoding failure, individual candidates are retried within the same constrained list; no larger or differently shaped symbols outside that list are allowed.

Eight regression tests cover fixed/automatic/partial dimensions, rectangular selection, invalid/conflicting/undersized requests, the compressible-content case, exact module scaling, and the complete ZPL → parser → renderer path. Integration fixtures use `_` as the explicit escape marker, as in the original repro; escape/FNC1 handling and legacy ECC support are unchanged.

Validation on Windows GNU, based on `c5ae3972`:
- Reproduced dimension/fallback/renderer failures on main before the fix.
- `cargo test --offline -j 1 --test unit_datamatrix`: 8 passed.
- `cargo test --offline -j 1 --test 'unit_*' --features skill -- --test-threads=4` passed.
- `cargo test --offline -j 1 --test e2e_diff_report -- --nocapture` passed; all 124 existing fixtures regenerated, both reports reviewed, no changed comparison artifacts.
- `cargo test --offline -j 1 --test e2e_golden -- --test-threads=4`: 120 passed.
- `cargo fmt --all -- --check` and `cargo clippy --offline -j 1 --all-features -- -D warnings` passed.

Related work: the width filter overlaps the correction already present in @roberto976's #8. This focused PR additionally handles ratio propagation, partial dimensions, constrained encoding failures, and regression coverage. It does not include the field-inversion changes from #8.

Reference: [Zebra ^BX](https://docs.zebra.com/us/en/printers/software/zpl-pg/c-zpl-zpl-commands/r-zpl-bx.html).