### PR TITLE
fix: reject unsupported DataMatrix qualities instead of encoding ECC 200

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,14 @@ std::fs::write("output.png", buf.into_inner()).unwrap();
 | **Label Control** | `^XA` `^XZ` `^PW` `^PO` `^LH` `^LR` `^LT` (label top) `^LS` (label shift) `^LL` (label length) `^CI` `^MU` (units of measurement) `^PQ` (print quantity) `^FX` (comment) `^SN`/`^SF` (serial state) |
 | **Stored Formats** | `^DF` `^XF` |
 
+DataMatrix rendering supports **ECC 200 only**. Specify quality `200` explicitly
+in ZPL, for example `^BXN,4,200`. Omitted or empty `^BX` quality defaults to ECC 000
+as specified by Zebra; qualities `0`, `50`, `80`, `100`, and `140` are parsed but
+return an unsupported-quality rendering error instead of silently producing an
+ECC 200 symbol. Invalid numeric qualities also return an error. EPL DataMatrix
+uses ECC 200 automatically. See the [Zebra ^BX reference](https://docs.zebra.com/us/en/printers/software/zpl-pg/c-zpl-zpl-commands/r-zpl-bx.html)
+and [EPL Programming Guide](https://www.zebra.com/content/dam/support-dam/en/documentation/unrestricted/guide/software/epl2-pm-en.pdf).
+
 ### EPL Commands
 
 `N` (new label) · `A` (text) · `B` (barcode) · `LO` (line draw) · `R` (reference point) · `P` (print)

--- a/src/drawers/renderer.rs
+++ b/src/drawers/renderer.rs
@@ -944,6 +944,22 @@ impl Renderer {
         canvas: &mut RgbaImage,
         bc: &crate::elements::barcode_datamatrix::BarcodeDatamatrixWithData,
     ) -> Result<(), String> {
+        // The encoder implements ECC 200 only. In ZPL, omitted quality is
+        // ECC 000, not permission to substitute a different symbology.
+        match bc.barcode.quality {
+            200 => {}
+            quality @ (0 | 50 | 80 | 100 | 140) => {
+                return Err(crate::error::LabelizeError::Render(format!(
+                    "Unsupported DataMatrix quality {quality}: only ECC 200 is supported; legacy ECC encoding is not implemented."
+                )).to_string());
+            }
+            quality => {
+                return Err(crate::error::LabelizeError::Render(format!(
+                    "Invalid DataMatrix quality {quality}: expected 0, 50, 80, 100, 140, or 200."
+                ))
+                .to_string());
+            }
+        }
         let scale = bc.barcode.height.max(1);
         let img_raw =
             barcodes::datamatrix::encode(&bc.data, scale, bc.barcode.rows, bc.barcode.columns)?;

--- a/src/parsers/epl_parser.rs
+++ b/src/parsers/epl_parser.rs
@@ -761,7 +761,7 @@ fn parse_epl_2d_barcode(
                         barcode: BarcodeDatamatrix {
                             orientation: FieldOrientation::Normal,
                             height: module,
-                            quality: 0,
+                            quality: 200, // EPL Data Matrix always uses ECC 200.
                             columns,
                             rows,
                             format: 6,

--- a/tests/unit_datamatrix_quality.rs
+++ b/tests/unit_datamatrix_quality.rs
@@ -1,0 +1,98 @@
+use labelize::elements::label_element::LabelElement;
+use labelize::{DrawerOptions, EplParser, LabelInfo, Renderer, ZplParser};
+use std::io::Cursor;
+
+fn parse(parameters: &str) -> LabelInfo {
+    let source = format!("^XA^FO20,20^BX{parameters}^FDAB12^FS^XZ");
+    ZplParser::new().parse(source.as_bytes()).unwrap().remove(0)
+}
+
+fn quality(label: &LabelInfo) -> i32 {
+    match &label.elements[0] {
+        LabelElement::BarcodeDatamatrix(bc) => bc.barcode.quality,
+        other => panic!("expected DataMatrix, got {other:?}"),
+    }
+}
+
+fn render(label: &LabelInfo) -> Result<Vec<u8>, String> {
+    let mut output = Cursor::new(Vec::new());
+    Renderer::new().draw_label_as_png(label, &mut output, DrawerOptions::default())?;
+    Ok(output.into_inner())
+}
+
+#[test]
+fn omitted_and_empty_quality_remain_zero_and_are_not_rendered_as_ecc200() {
+    for parameters in ["N,4", "N,4,", "N,4,,0,0,6"] {
+        let label = parse(parameters);
+        assert_eq!(quality(&label), 0);
+        let error = render(&label)
+            .err()
+            .expect("ECC 000 must not silently become ECC 200");
+        assert!(
+            error.contains("Unsupported DataMatrix quality 0"),
+            "{error}"
+        );
+    }
+}
+
+#[test]
+fn all_legacy_qualities_are_preserved_and_reported_as_unsupported() {
+    for value in ["0", "000", "50", "050", "80", "080", "100", "140"] {
+        let label = parse(&format!("N,4,{value}"));
+        let expected = value.parse::<i32>().unwrap();
+        assert_eq!(quality(&label), expected);
+        let error = render(&label)
+            .err()
+            .expect("legacy encoder is not implemented");
+        assert!(
+            error.contains(&format!("Unsupported DataMatrix quality {expected}")),
+            "{error}"
+        );
+        assert!(error.contains("only ECC 200 is supported"), "{error}");
+    }
+}
+
+#[test]
+fn invalid_numeric_quality_is_not_rendered_as_ecc200() {
+    for value in [-1, 42, 201] {
+        let error = render(&parse(&format!("N,4,{value}")))
+            .err()
+            .expect("invalid quality must fail");
+        assert!(
+            error.contains(&format!("Invalid DataMatrix quality {value}")),
+            "{error}"
+        );
+    }
+}
+
+#[test]
+fn quality_defaults_do_not_inherit_ecc200_from_previous_fields_or_labels() {
+    let source = b"^XA^FO20,20^BXN,4,200^FDAB12^FS^FO80,20^BXN,4^FDAB12^FS^XZ\
+                   ^XA^FO20,20^BXN,4,^FDAB12^FS^XZ";
+    let labels = ZplParser::new().parse(source).unwrap();
+    assert_eq!(labels.len(), 2);
+    assert_eq!(quality(&labels[0]), 200);
+    match &labels[0].elements[1] {
+        LabelElement::BarcodeDatamatrix(bc) => assert_eq!(bc.barcode.quality, 0),
+        other => panic!("expected DataMatrix, got {other:?}"),
+    }
+    for label in &labels {
+        assert!(render(label)
+            .err()
+            .expect("omitted quality must fail")
+            .contains("Unsupported DataMatrix quality 0"));
+    }
+}
+
+#[test]
+fn epl_explicitly_uses_ecc200_and_matches_zpl_rendering() {
+    let epl = EplParser::new()
+        .parse(b"N\nb20,20,D,h4,\"AB12\"\nP1\n")
+        .unwrap();
+    let zpl = parse("N,4,200");
+    assert_eq!(quality(&epl[0]), 200);
+    let png = render(&zpl).expect("explicit ECC 200 must still render");
+    let image = image::load_from_memory(&png).unwrap().to_rgba8();
+    assert!(image.pixels().any(|pixel| pixel[0] == 0 && pixel[3] != 0));
+    assert_eq!(render(&epl[0]).unwrap(), png);
+}


### PR DESCRIPTION
The renderer currently ignores DataMatrix quality and produces ECC 200 even for `^BXN,4` (whose default is ECC 000) or explicit legacy qualities. This change rejects unsupported qualities 0, 50, 80, 100, and 140 with a clear rendering error, and distinguishes invalid numeric values. Explicit ECC 200 continues to use the existing encoder.

The ZPL parser already defaults omitted/empty quality to 0 and remains unchanged. The EPL parser now explicitly records quality 200, matching EPL's DataMatrix semantics and preserving its rendered output. The README documents the supported quality and the behavior change for ZPL that omits it. Legacy encoders and Escape/FNC1 processing are outside this change.

Regression coverage includes omitted/empty quality, all legacy values including leading-zero spellings, invalid numeric values, defaults across fields and labels, and identical EPL/explicit-ZPL ECC 200 rendering.

Validation:
- 269 library/unit tests passed, including 35 property tests and 5 new quality tests.
- All 120 golden tests passed; no tolerance changes.
- Both diff-report tests passed. Regenerated comparison images and reports are unchanged; no reference images were replaced or created.
- `cargo fmt --check` and `git diff --check` passed.

Local Windows validation required linking the installed MinGW `libwinpthread.dll.a` explicitly for the property, golden, and diff-report test binaries to resolve an existing `nanosleep64` toolchain mismatch. This was a local build option only; no build configuration or dependencies were changed.

References: [Zebra ^BX documentation](https://docs.zebra.com/us/en/printers/software/zpl-pg/c-zpl-zpl-commands/r-zpl-bx.html) (quality default 0), [EPL Programming Guide](https://www.zebra.com/content/dam/support-dam/en/documentation/unrestricted/guide/software/epl2-pm-en.pdf) (DataMatrix uses ECC 200).
